### PR TITLE
Make the checker unable to pass while verifying nothing

### DIFF
--- a/.github/workflows/family-links.yml
+++ b/.github/workflows/family-links.yml
@@ -28,8 +28,12 @@ jobs:
 
       # Deliberately unauthenticated. A token can see private repositories and
       # would report the exact drift this check exists to catch as healthy.
+      # The weekly run is the primary guard and requires a complete reality
+      # check; push/PR runs stay tolerant of flaky networks.
       - name: check registry against GitHub
-        run: python3 -B tools/check_registry.py
+        run: >-
+          python3 -B tools/check_registry.py
+          ${{ github.event_name == 'schedule' && '--require-reality' || '' }}
 
       - name: check generated blocks are up to date
         run: python3 -B tools/render.py --check
@@ -63,11 +67,27 @@ jobs:
     needs: [registry, links]
     if: failure() && github.event_name == 'schedule'
     steps:
+      # Both labels (stale-pointer and severity:high) are assumed to exist;
+      # do not delete them from the repository.
       - name: file a stale-pointer issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          existing_issue="$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label stale-pointer \
+            --json number,title \
+            --jq '[.[] | select(.title | startswith("Weekly check failed"))][0].number // empty')"
+
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" \
+              --repo "${{ github.repository }}" \
+              --body "Another weekly family-links run failed: $RUN_URL"
+            exit 0
+          fi
+
           gh issue create \
             --repo "${{ github.repository }}" \
             --title "Weekly check failed: the map no longer matches reality" \

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "note": "Canonical list of Family OS modules. Everything the documentation says about where a module lives and whether it is open comes from here. Edit this file, run tools/render.py, and every generated block in every language follows. tools/check_registry.py verifies these claims against GitHub itself.",
+  "note": "Canonical list of Family OS modules. Generated tables in the engineering and visual-system docs come from here; README status wording in all four languages is maintained by hand and checked by tools/check_registry.py. Edit this file, run tools/render.py, and keep those README labels in sync; the checker verifies the claims against GitHub itself.",
   "languages": ["en", "ja", "zh", "th"],
   "note_separator": {
     "en": "; ",
@@ -19,7 +19,7 @@
       "en": "publication in preparation",
       "ja": "公開準備中",
       "zh": "准备公开中",
-      "th": "กำลังเตรียมเปิดสู่สาธารณะ"
+      "th": "กำลังเตรียมเปิด"
     }
   },
   "modules": [

--- a/tools/check_registry.py
+++ b/tools/check_registry.py
@@ -57,40 +57,67 @@ def status_span(text: str, start: int) -> str:
     return text[start:end]
 
 
-def github_is_public(repo: str, timeout: float = 20.0) -> "bool | None":
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Expose repository renames instead of following them."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def github_is_public(repo: str, timeout: float = 20.0):
     """Anonymous check, deliberately unauthenticated.
 
     A token would see private repositories and report them as fine — which is
-    exactly the blindness this check exists to remove. Returns None when GitHub
-    could not be reached, so a flaky network never reads as a failure.
+    exactly the blindness this check exists to remove. The web endpoint keeps
+    that anonymity while sidestepping the anonymous API's 60-request-per-hour
+    quota, which made skips common on shared CI runner IPs. Redirects are not
+    followed so repository renames become detectable drift.
+
+    Returns True for a public repository, False for private/absent, a
+    ``("moved", location)`` tuple for a redirect, and None when GitHub could not
+    be reached. Push and pull-request runs intentionally leave that last case
+    non-fatal, so a flaky network never reads as a confirmed mismatch.
     """
     request = urllib.request.Request(
-        "https://api.github.com/repos/%s" % repo,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "family-os-registry-check",
-        },
+        "https://github.com/%s" % repo,
+        method="HEAD",
+        headers={"User-Agent": "family-os-registry-check"},
     )
+    opener = urllib.request.build_opener(NoRedirectHandler())
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            json.load(response)
-            return True
+        with opener.open(request, timeout=timeout) as response:
+            if response.status == 200:
+                return True
+            return None
     except urllib.error.HTTPError as exc:
+        if exc.code in (301, 302, 307, 308):
+            return "moved", exc.headers.get("Location")
         if exc.code == 404:
             return False
-        if exc.code in (403, 429):
+        if exc.code in (403, 429) or 500 <= exc.code <= 599:
             return None
         raise
     except (urllib.error.URLError, TimeoutError):
         return None
 
 
-def check_reality(registry: dict, failures: list, notes: list) -> None:
+def check_reality(
+    registry: dict, failures: list, notes: list, require_reality: bool = False
+) -> int:
+    skipped = 0
     for module in registry["modules"]:
         repo = module["repo"]
         public = github_is_public(repo)
         if public is None:
             notes.append("%s: could not reach GitHub, reality check skipped" % repo)
+            skipped += 1
+            continue
+        if isinstance(public, tuple) and public[0] == "moved":
+            failures.append(
+                "moved: %s redirects to %s. Update registry/modules.json with "
+                "the current repository name and re-run tools/render.py."
+                % (repo, public[1] or "an unspecified location")
+            )
             continue
         expected_public = module["status"] == "published"
         if public != expected_public:
@@ -100,6 +127,12 @@ def check_reality(registry: dict, failures: list, notes: list) -> None:
                 "tools/render.py."
                 % (repo, module["status"], "PUBLIC" if public else "PRIVATE/absent")
             )
+    if require_reality and skipped:
+        failures.append(
+            "degraded: could not verify %d modules; --require-reality rejects "
+            "this degraded run, not a confirmed registry mismatch" % skipped
+        )
+    return skipped
 
 
 def check_retired(registry: dict, root: pathlib.Path, failures: list) -> None:
@@ -110,8 +143,9 @@ def check_retired(registry: dict, root: pathlib.Path, failures: list) -> None:
         text = path.read_text(encoding="utf-8")
         for repo, entry in retired.items():
             needle = "github.com/%s" % repo
-            if needle in text:
-                line = text[: text.index(needle)].count("\n") + 1
+            pattern = re.compile(re.escape(needle) + r"(?![A-Za-z0-9_-])")
+            for match in pattern.finditer(text):
+                line = text[: match.start()].count("\n") + 1
                 failures.append(
                     "retired: %s:%d links to %s, which has moved to %s (%s)"
                     % (
@@ -135,15 +169,13 @@ def check_status_text(registry: dict, root: pathlib.Path, failures: list) -> int
 
         for module in registry["modules"]:
             url = "https://github.com/%s" % module["repo"]
+            pattern = re.compile(re.escape(url) + r"(?![A-Za-z0-9_-])")
             correct = module["status"]
             wrong = [s for s in statuses if s != correct]
 
-            start = 0
-            while True:
-                index = text.find(url, start)
-                if index == -1:
-                    break
-                start = index + len(url)
+            for match in pattern.finditer(text):
+                index = match.start()
+                start = match.end()
                 window = status_span(text, start)
 
                 for status in wrong:
@@ -174,12 +206,19 @@ def main() -> int:
         help="skip the GitHub reality check",
     )
     parser.add_argument(
+        "--require-reality",
+        action="store_true",
+        help="fail if any module cannot be checked against GitHub",
+    )
+    parser.add_argument(
         "--root",
         type=pathlib.Path,
         default=REPO_ROOT,
         help="repository checkout to inspect (default: the checkout containing this script)",
     )
     args = parser.parse_args()
+    if args.offline and args.require_reality:
+        parser.error("--require-reality cannot be combined with --offline")
 
     root = args.root.expanduser().resolve()
     registry_path = root / "registry" / "modules.json"
@@ -192,8 +231,9 @@ def main() -> int:
     failures: list = []
     notes: list = []
 
+    skipped = 0
     if not args.offline:
-        check_reality(registry, failures, notes)
+        skipped = check_reality(registry, failures, notes, args.require_reality)
     check_retired(registry, root, failures)
     occurrences = check_status_text(registry, root, failures)
 
@@ -201,6 +241,8 @@ def main() -> int:
     print("retired repositories: %d" % len(registry.get("retired_repos", [])))
     print("link occurrences    : %d" % occurrences)
     print("reality check       : %s" % ("skipped" if args.offline else "on (anonymous)"))
+    if not args.offline:
+        print("reality skipped    : %d of %d" % (skipped, len(registry["modules"])))
 
     for note in notes:
         print("  note: %s" % note)

--- a/tools/render.py
+++ b/tools/render.py
@@ -19,7 +19,6 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 REGISTRY = REPO_ROOT / "registry" / "modules.json"
 
 LANG_SUFFIX = re.compile(r"\.(?P<lang>[a-z]{2}(?:-[A-Z]{2})?)\.md$")
-MARKER_PREFIX = "<!-- family:generated:"
 MARKER = re.compile(
     r"^<!-- family:generated:(?P<block>[a-z0-9][a-z0-9-]*):"
     r"(?P<edge>start|end) -->$"
@@ -55,12 +54,22 @@ def markdown_files(root: pathlib.Path):
 
 def marker_line(line: str):
     content = line.rstrip("\r\n")
-    if MARKER_PREFIX not in content:
+    if "family:generated" not in content.lower():
         return None
     match = MARKER.fullmatch(content)
     if not match:
         raise RenderError("malformed generated marker: %s" % content)
     return match.group("block"), match.group("edge")
+
+
+def table_cell(module: dict, field: str, value: str) -> str:
+    """Reject registry data that would change the generated table structure."""
+    if "|" in value or "\n" in value or "\r" in value:
+        raise RenderError(
+            "module '%s' field '%s' contains a table delimiter or newline"
+            % (module.get("id", "<unknown>"), field)
+        )
+    return value
 
 
 def find_regions(path: pathlib.Path, text: str):
@@ -118,15 +127,20 @@ def find_regions(path: pathlib.Path, text: str):
 
 
 def state_text(registry: dict, module: dict, lang: str) -> str:
-    state = registry["status_labels"][module["status"]][lang]
+    state = table_cell(
+        module,
+        "state.%s" % lang,
+        registry["status_labels"][module["status"]][lang],
+    )
     note = module.get("note", {}).get(lang)
     if note:
+        note = table_cell(module, "note.%s" % lang, note)
         try:
             separator = registry["note_separator"][lang]
         except KeyError:
             raise RenderError("note_separator is missing language '%s'" % lang)
         state += separator + note
-    return state
+    return table_cell(module, "state.%s" % lang, state)
 
 
 def render_inventory(registry: dict, lang: str) -> str:
@@ -140,10 +154,10 @@ def render_inventory(registry: dict, lang: str) -> str:
         rows.append(
             "| [%s](https://github.com/%s) | %s | %s | %s |"
             % (
-                module["name"],
-                module["repo"],
-                module["class"][lang],
-                module["owns"][lang],
+                table_cell(module, "name", module["name"]),
+                table_cell(module, "repo", module["repo"]),
+                table_cell(module, "class.%s" % lang, module["class"][lang]),
+                table_cell(module, "owns.%s" % lang, module["owns"][lang]),
                 state_text(registry, module, lang),
             )
         )
@@ -155,7 +169,11 @@ def render_repository_links(registry: dict) -> str:
     for module in registry["modules"]:
         rows.append(
             "| %s | `%s` | %s |"
-            % (module["name"], module["repo"], state_text(registry, module, "en"))
+            % (
+                table_cell(module, "name", module["name"]),
+                table_cell(module, "repo", module["repo"]),
+                state_text(registry, module, "en"),
+            )
         )
     return "\n".join(rows)
 


### PR DESCRIPTION
## Why

An independent two-reviewer pass over the week-old link-rot tooling returned two NO-GO verdicts. Both reviewers converged on the same worst case, and both proved it: when GitHub's anonymous API quota (60 req/h, shared across CI runner IPs — one reviewer's live run skipped 5 of 8 modules) or any network failure struck, the reality check skipped every module with a note and still printed `OK — every module claim matches the registry.` with exit 0. The weekly scheduled run — the primary guard, the reason this tooling exists — could stay green for weeks while verifying nothing.

## What changed

**`tools/check_registry.py`**
- The reality check now asks `https://github.com/<repo>` (HEAD, still deliberately anonymous) instead of the rate-limited API.
- Redirects are no longer followed: a 3xx is reported as a new hard failure (`moved:`) — a renamed repository stops hiding behind its forwarding address, which dies the day the old name is re-claimed.
- New `--require-reality` flag: any skipped module fails the run as `degraded:` (worded apart from a confirmed mismatch). Rejected when combined with `--offline`.
- Both the status-text scan and the retired-repo scan anchor matches with `(?![A-Za-z0-9_-])`, so a link to `…/sitter-plugin` is no longer blamed for Sitter's label and `…/family-os-public` no longer trips the retired `…/family-os` needle (both false positives were reproduced before fixing).

**`registry/modules.json`**
- The Thai "preparing" label is now the short form the Thai pages actually write — the previous long form appeared next to no link, so Thai stale-label detection could never fire.
- The note no longer overpromises: generated blocks cover the engineering/visual-system docs; README status wording in all four languages is hand-maintained and checked, not generated.

**`tools/render.py`**
- A line containing `family:generated` that is not an exact marker now fails loudly (previously a no-space typo marker was silently ignored).
- Registry values containing `|` or a newline fail rendering instead of silently bending the emitted tables.

**`.github/workflows/family-links.yml`**
- The scheduled run passes `--require-reality`; push/PR runs stay tolerant of flaky networks, as designed.
- The failure report appends to an open "Weekly check failed" issue instead of filing a duplicate every Monday.

## Verification

- `python3 -B tools/check_registry.py` (live, anonymous): 8/8 modules resolved, 0 skipped, exit 0.
- `python3 -B tools/check_registry.py --offline` and `python3 -B tools/render.py --check`: green on the clean tree; generated blocks unchanged by the registry edits.
- Fixture probes: both false positives gone while three true positives (stale label, retired bare URL, retired URL with `/issues/…` path) still fire; typo marker and `|`-in-value both fail loudly; with reachability stubbed to "unknown" for all modules, the default run stays exit 0 with notes and `--require-reality` exits 1 with the degraded message.
- Both original reviewers re-reviewed this exact commit (delta review); verdicts recorded in the review log.

Deferred as follow-ups (deliberately, latent today): wrong-label-before-link invisibility + status-window truncation (all current pages put the label directly after the link), lychee's exclude list duplicating registry data, URL form variants (`http://`, `www.`, bare `owner/repo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
