### PR TITLE
Flip the footer flag: all five published modules now enforced

### DIFF
--- a/registry/modules.json
+++ b/registry/modules.json
@@ -1,7 +1,12 @@
 {
   "version": 1,
   "note": "Canonical list of Family OS modules. Generated tables in the engineering and visual-system docs come from here; README status wording in all four languages is maintained by hand and checked by tools/check_registry.py. Edit this file, run tools/render.py, and keep those README labels in sync; the checker verifies the claims against GitHub itself.",
-  "languages": ["en", "ja", "zh", "th"],
+  "languages": [
+    "en",
+    "ja",
+    "zh",
+    "th"
+  ],
   "map_repo": "caty-ai/family-os",
   "footer_text": {
     "intro": {
@@ -51,7 +56,8 @@
       "owns": {
         "en": "task meaning, attempt, retry, checkpoint, done-check, completion, dead-letter",
         "ja": "タスクの意味・試行・リトライ・チェックポイント・完了判定・完了・DLQ"
-      }
+      },
+      "footer": true
     },
     {
       "id": "persona-engine",
@@ -69,7 +75,8 @@
       "owns": {
         "en": "persona layers and emotion gradation",
         "ja": "人格のレイヤーと感情のグラデーション"
-      }
+      },
+      "footer": true
     },
     {
       "id": "sitter",
@@ -84,7 +91,8 @@
       "owns": {
         "en": "local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart",
         "ja": "ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動"
-      }
+      },
+      "footer": true
     },
     {
       "id": "x-collector",
@@ -99,7 +107,8 @@
       "owns": {
         "en": "collecting external material for the ability loop",
         "ja": "能力ループ向けの外部素材の収集"
-      }
+      },
+      "footer": true
     },
     {
       "id": "family-dev-handbook",
@@ -114,7 +123,8 @@
       "owns": {
         "en": "issue, PR, worktree, handoff, and parallel-development rules",
         "ja": "Issue・PR・worktree・受け渡し・並行開発のルール"
-      }
+      },
+      "footer": true
     },
     {
       "id": "family-memory-architecture",


### PR DESCRIPTION
Final child of #5. B1–B5 are merged in the five sibling repositories; this flips `footer: true` for all published modules, arming byte-exact enforcement. Verified against the live siblings before this PR: `check --require-reality` green, zero skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)