### PR TITLE
Make the footer answer the visitor's real question: what is each module

### DIFF
--- a/docs/family-footer-contract.md
+++ b/docs/family-footer-contract.md
@@ -2,6 +2,8 @@
 
 The family footer is one generated region per declared root `README*.md` in sibling repositories. Literal generated marker lines may appear in documentation only inside fenced code blocks.
 
+The v3.1 content amendment replaces v3's sibling list with a full-module table. Marker parsing, declared files, byte-exact comparison, and all four enforcement rules are unchanged.
+
 ## Markers
 
 ```html
@@ -11,7 +13,11 @@ The family footer is one generated region per declared root `README*.md` in sibl
 
 {intro with {map} replaced by [Family OS](https://github.com/<map_repo>)}
 
-{siblings_label}: [Name](https://github.com/<repo>) · [Name](https://github.com/<repo>)
+| Module | What it does | State |
+| --- | --- | --- |
+| **Host Module** | {tagline for this language} | {status label for this language} |
+| [Published Module](https://github.com/<repo>) | {tagline for this language} | {status label for this language} |
+| **Preparing Module** | {tagline for this language} | {status label for this language} |
 
 <!-- family:generated:family-footer:end -->
 ```
@@ -19,6 +25,15 @@ The family footer is one generated region per declared root `README*.md` in sibl
 - The block id is `family-footer`.
 - The content inside the region always has a leading blank line and a trailing blank line.
 - The renderer preserves the start marker's newline bytes and compares only the bytes between the markers.
+
+## Content
+
+- The table contains every registry module in registry order, including modules still being prepared and the repository hosting the footer.
+- A published module name links to its repository, except that the host row is bold and unlinked. A preparing module name is also bold and unlinked, so the footer shows the full map without shipping an intentional `404` link.
+- The localized description comes from the module's required `tagline` registry field. Every tagline must define every registry language.
+- The localized state comes directly from `status_labels`; module `note` fields are not rendered.
+- The three localized headers come from `footer_text.table_module`, `footer_text.table_what`, and `footer_text.table_state`.
+- Header, module-name, tagline, and status-label cells fail validation if they contain a pipe or newline, rather than emitting a malformed Markdown table.
 
 ## Declared Files
 

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -15,11 +15,23 @@
       "zh": "本仓库属于 **Caty AI 家族** — 用于运营 AI 智能体家族的开源工具集。完整地图（包括仍在准备公开的模块）见 {map}。",
       "th": "รีโพนี้เป็นส่วนหนึ่งของ **ครอบครัว Caty AI** — ชุดเครื่องมือโอเพนซอร์สสำหรับดูแลครอบครัวเอเจนต์ AI แผนที่ฉบับเต็ม (รวมโมดูลที่กำลังเตรียมเปิด) อยู่ที่ {map}"
     },
-    "siblings_label": {
-      "en": "Siblings",
-      "ja": "兄弟モジュール",
-      "zh": "同家族模块",
-      "th": "โมดูลพี่น้อง"
+    "table_module": {
+      "en": "Module",
+      "ja": "モジュール",
+      "zh": "模块",
+      "th": "โมดูล"
+    },
+    "table_what": {
+      "en": "What it does",
+      "ja": "何をするもの",
+      "zh": "做什么",
+      "th": "ทำอะไร"
+    },
+    "table_state": {
+      "en": "State",
+      "ja": "状態",
+      "zh": "状态",
+      "th": "สถานะ"
     }
   },
   "note_separator": {
@@ -48,6 +60,12 @@
       "name": "Caty Agent Harness",
       "repo": "caty-ai/caty-agent-harness",
       "status": "published",
+      "tagline": {
+        "en": "Task backbone for AI agents — retries, checkpoints, and honest completion",
+        "ja": "AIエージェントのタスク基盤 — 試行・リトライ・チェックポイント・完了判定",
+        "zh": "AI 智能体的任务基座 — 重试、检查点与完成判定",
+        "th": "แกนงานของเอเจนต์ AI — การลองใหม่ เช็คพอยต์ และการตัดสินว่าเสร็จจริง"
+      },
       "license": "MIT",
       "class": {
         "en": "runtime, vertical foundation",
@@ -64,6 +82,12 @@
       "name": "Persona Engine",
       "repo": "caty-ai/persona-engine",
       "status": "published",
+      "tagline": {
+        "en": "Gives an agent a persona — layered personality and graded emotion",
+        "ja": "エージェントに人格を与える — 人格レイヤーと感情のグラデーション",
+        "zh": "为智能体赋予人格 — 分层人格与情感渐变",
+        "th": "มอบบุคลิกให้เอเจนต์ — เลเยอร์บุคลิกและอารมณ์แบบไล่ระดับ"
+      },
       "readme_overrides": {
         "README.zh-CN.md": "zh"
       },
@@ -83,6 +107,12 @@
       "name": "Sitter",
       "repo": "caty-ai/sitter",
       "status": "published",
+      "tagline": {
+        "en": "Babysits delegated agent runs — watches, keeps evidence, restarts",
+        "ja": "委譲したエージェント実行の見張り番 — 監視・証拠の記録・再起動",
+        "zh": "替你盯着委派出去的智能体 — 监视、留证、重启",
+        "th": "พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ต"
+      },
       "license": "MIT",
       "class": {
         "en": "runtime, observation",
@@ -99,6 +129,12 @@
       "name": "X Collector",
       "repo": "caty-ai/x-collector",
       "status": "published",
+      "tagline": {
+        "en": "Turns X and the web into one daily digest — for people and agents",
+        "ja": "Xやウェブの素材を1日1回のダイジェストに — 人にもエージェントにも",
+        "zh": "把 X 与网络素材汇成每日一份摘要 — 给人也给智能体",
+        "th": "รวบรวมข้อมูลจาก X และเว็บเป็นสรุปวันละฉบับ — สำหรับคนและเอเจนต์"
+      },
       "license": "MIT",
       "class": {
         "en": "runtime, optional input",
@@ -115,6 +151,12 @@
       "name": "Family Dev Handbook",
       "repo": "caty-ai/family-dev-handbook",
       "status": "published",
+      "tagline": {
+        "en": "The rules of the road — issues, PRs, worktrees, handoffs, parallel development",
+        "ja": "開発の交通ルール — Issue・PR・worktree・受け渡し・並行開発",
+        "zh": "开发的交通规则 — Issue、PR、worktree、交接与并行开发",
+        "th": "กติกากลางของการพัฒนา — Issue, PR, worktree, การส่งงานต่อ และการทำงานคู่ขนาน"
+      },
       "license": "MIT",
       "class": {
         "en": "non-runtime governance",
@@ -131,6 +173,12 @@
       "name": "Family Memory Architecture",
       "repo": "shojikumaru/family-memory-architecture",
       "status": "preparing",
+      "tagline": {
+        "en": "The memory bus — how the family shares what it knows",
+        "ja": "記憶バス — 家族が知っていることを共有する層",
+        "zh": "记忆总线 — 家族共享所知的一层",
+        "th": "บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้"
+      },
       "license": null,
       "class": {
         "en": "runtime, horizontal infrastructure",
@@ -146,6 +194,12 @@
       "name": "Self Growth Loop",
       "repo": "shojikumaru/self-growth-loop",
       "status": "preparing",
+      "tagline": {
+        "en": "Lets an agent grow its own abilities — proposals, governance, adoption records",
+        "ja": "エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録",
+        "zh": "让智能体自我成长的循环 — 提案、治理与采用记录",
+        "th": "วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง — ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้"
+      },
       "license": null,
       "class": {
         "en": "runtime, application",
@@ -165,6 +219,12 @@
       "name": "Persona Growth Loop",
       "repo": "shojikumaru/persona-growth-loop",
       "status": "preparing",
+      "tagline": {
+        "en": "Grows the persona itself — minimal, idempotent proposals",
+        "ja": "人格そのものを育てる — 最小・冪等な提案づくり",
+        "zh": "让人格本身成长 — 以最小且幂等的提案",
+        "th": "พัฒนาบุคลิกของเอเจนต์ — สร้างข้อเสนอแบบน้อยที่สุดและทำซ้ำได้"
+      },
       "license": null,
       "class": {
         "en": "planned frontend",

--- a/tools/family_footer.py
+++ b/tools/family_footer.py
@@ -80,12 +80,20 @@ def validate_footer_text_value(label: str, value: str) -> None:
         raise FooterError("%s may not contain generated-marker text" % label)
 
 
+def validate_table_cell_value(label: str, value: str) -> None:
+    validate_footer_text_value(label, value)
+    if "|" in value:
+        raise FooterError("%s may not contain '|'" % label)
+
+
 def validate_module_name(module: dict) -> None:
     name = module.get("name")
     if not isinstance(name, str):
         raise FooterError("name must be a string")
     if "\n" in name or "\r" in name:
         raise FooterError("name may not contain a newline")
+    if "|" in name:
+        raise FooterError("name may not contain '|'")
     if "]" in name:
         raise FooterError("name may not contain ']'")
     if MARKER_TOKEN in name.lower():
@@ -187,7 +195,7 @@ def lint_registry(registry: dict) -> List[str]:
     if not isinstance(footer_text, dict):
         failures.append("registry/modules.json: footer_text must be an object")
     else:
-        for key in ("intro", "siblings_label"):
+        for key in ("intro", "table_module", "table_what", "table_state"):
             section = footer_text.get(key)
             if not isinstance(section, dict):
                 failures.append("registry/modules.json: footer_text.%s must be an object" % key)
@@ -196,12 +204,33 @@ def lint_registry(registry: dict) -> List[str]:
                 value = section.get(lang)
                 label = "registry/modules.json: footer_text.%s.%s" % (key, lang)
                 try:
-                    validate_footer_text_value(label, value)
+                    if key == "intro":
+                        validate_footer_text_value(label, value)
+                    else:
+                        validate_table_cell_value(label, value)
                 except FooterError as exc:
                     failures.append(str(exc))
                     continue
                 if key == "intro" and value.count("{map}") != 1:
                     failures.append("%s must contain exactly one {map} placeholder" % label)
+
+    status_labels = registry.get("status_labels")
+    if not isinstance(status_labels, dict):
+        failures.append("registry/modules.json: status_labels must be an object")
+        status_labels = {}
+    else:
+        for status, section in status_labels.items():
+            if not isinstance(section, dict):
+                failures.append(
+                    "registry/modules.json: status_labels.%s must be an object" % status
+                )
+                continue
+            for lang in languages:
+                label = "registry/modules.json: status_labels.%s.%s" % (status, lang)
+                try:
+                    validate_table_cell_value(label, section.get(lang))
+                except FooterError as exc:
+                    failures.append(str(exc))
 
     modules = registry.get("modules")
     if not isinstance(modules, list):
@@ -218,6 +247,19 @@ def lint_registry(registry: dict) -> List[str]:
             validate_module_name(module)
         except FooterError as exc:
             failures.append("%s: %s" % (label, exc))
+        tagline = module.get("tagline")
+        if not isinstance(tagline, dict):
+            failures.append("%s: tagline must be an object" % label)
+        else:
+            for lang in languages:
+                tagline_label = "%s: tagline.%s" % (label, lang)
+                try:
+                    validate_table_cell_value(tagline_label, tagline.get(lang))
+                except FooterError as exc:
+                    failures.append(str(exc))
+        status = module.get("status")
+        if status not in status_labels:
+            failures.append("%s: status must name an entry in status_labels" % label)
         if "footer" in module and not isinstance(module["footer"], bool):
             failures.append("%s: footer must be a boolean when present" % label)
         if footer_enabled(module) and module.get("status") != "published":
@@ -234,25 +276,48 @@ def map_link(registry: dict) -> str:
     return "[Family OS](https://github.com/%s)" % registry["map_repo"]
 
 
-def siblings_line(registry: dict, module: dict, lang: str) -> str:
-    links = []
-    for sibling in published_modules(registry):
-        if sibling["repo"] == module["repo"]:
-            continue
-        links.append("[%s](https://github.com/%s)" % (sibling["name"], sibling["repo"]))
-    return "%s: %s" % (registry["footer_text"]["siblings_label"][lang], " · ".join(links))
+def module_table(registry: dict, host_module: dict, lang: str, newline: str) -> str:
+    footer_text = registry["footer_text"]
+    headers = [
+        ("table_module", footer_text["table_module"][lang]),
+        ("table_what", footer_text["table_what"][lang]),
+        ("table_state", footer_text["table_state"][lang]),
+    ]
+    for key, value in headers:
+        validate_table_cell_value("footer_text.%s.%s" % (key, lang), value)
+
+    rows = [
+        "| %s | %s | %s |" % tuple(value for _key, value in headers),
+        "| --- | --- | --- |",
+    ]
+    for module in registry["modules"]:
+        name = module["name"]
+        tagline = module["tagline"][lang]
+        status = registry["status_labels"][module["status"]][lang]
+        validate_table_cell_value("%s name" % module_label(module), name)
+        validate_table_cell_value("%s tagline.%s" % (module_label(module), lang), tagline)
+        validate_table_cell_value(
+            "status_labels.%s.%s" % (module["status"], lang), status
+        )
+
+        if module["repo"] == host_module["repo"] or module["status"] != "published":
+            rendered_name = "**%s**" % name
+        else:
+            rendered_name = "[%s](https://github.com/%s)" % (name, module["repo"])
+        rows.append("| %s | %s | %s |" % (rendered_name, tagline, status))
+    return newline.join(rows)
 
 
 def render_region(registry: dict, module: dict, lang: str, newline: str) -> str:
     intro = registry["footer_text"]["intro"][lang].replace("{map}", map_link(registry))
-    sibling_text = siblings_line(registry, module, lang)
+    table = module_table(registry, module, lang, newline)
     return (
         newline
         + "---"
         + newline * 2
         + intro
         + newline * 2
-        + sibling_text
+        + table
         + newline * 2
     )
 

--- a/tools/selftest_family_footer.py
+++ b/tools/selftest_family_footer.py
@@ -13,7 +13,9 @@ from family_footer import (
     END_MARKER,
     START_MARKER,
     FetchResult,
+    FooterError,
     check_registry_footers,
+    lint_registry,
     render_region,
     render_repo_to_target,
     resolve_declared_readmes,
@@ -31,11 +33,37 @@ def base_registry():
                 "zh": "Intro {map}.",
                 "th": "Intro {map}.",
             },
-            "siblings_label": {
-                "en": "Siblings",
-                "ja": "Siblings",
-                "zh": "Siblings",
-                "th": "Siblings",
+            "table_module": {
+                "en": "Module",
+                "ja": "モジュール",
+                "zh": "模块",
+                "th": "โมดูล",
+            },
+            "table_what": {
+                "en": "What it does",
+                "ja": "何をするもの",
+                "zh": "做什么",
+                "th": "ทำอะไร",
+            },
+            "table_state": {
+                "en": "State",
+                "ja": "状態",
+                "zh": "状态",
+                "th": "สถานะ",
+            },
+        },
+        "status_labels": {
+            "published": {
+                "en": "published",
+                "ja": "公開",
+                "zh": "已公开",
+                "th": "เปิดแล้ว",
+            },
+            "preparing": {
+                "en": "preparing",
+                "ja": "準備中",
+                "zh": "准备中",
+                "th": "กำลังเตรียม",
             },
         },
         "modules": [
@@ -44,12 +72,24 @@ def base_registry():
                 "name": "Alpha",
                 "repo": "caty-ai/alpha",
                 "status": "published",
+                "tagline": {
+                    "en": "Alpha work",
+                    "ja": "Alpha の仕事",
+                    "zh": "Alpha 的工作",
+                    "th": "งานของ Alpha",
+                },
             },
             {
                 "id": "beta",
                 "name": "Beta",
                 "repo": "caty-ai/beta",
                 "status": "published",
+                "tagline": {
+                    "en": "Beta work",
+                    "ja": "Beta の仕事",
+                    "zh": "Beta 的工作",
+                    "th": "งานของ Beta",
+                },
                 "readme_overrides": {"README.zh-CN.md": "zh"},
             },
             {
@@ -57,6 +97,12 @@ def base_registry():
                 "name": "Gamma",
                 "repo": "caty-ai/gamma",
                 "status": "preparing",
+                "tagline": {
+                    "en": "Gamma work",
+                    "ja": "Gamma の仕事",
+                    "zh": "Gamma 的工作",
+                    "th": "งานของ Gamma",
+                },
             },
         ],
         "retired_repos": [],
@@ -184,13 +230,58 @@ def test_declared_set_resolution():
     assert reduced_files == [("README.md", "en"), ("README.zh.md", "zh")]
 
 
+def test_table_rendering():
+    registry = base_registry()
+    region = render_region(registry, registry["modules"][0], "en", "\n")
+    table_lines = [line for line in region.splitlines() if line.startswith("|")]
+    assert table_lines == [
+        "| Module | What it does | State |",
+        "| --- | --- | --- |",
+        "| **Alpha** | Alpha work | published |",
+        "| [Beta](https://github.com/caty-ai/beta) | Beta work | published |",
+        "| **Gamma** | Gamma work | preparing |",
+    ]
+    assert "https://github.com/caty-ai/alpha" not in region
+    assert "https://github.com/caty-ai/gamma" not in region
+
+    ja_region = render_region(registry, registry["modules"][0], "ja", "\n")
+    assert "| モジュール | 何をするもの | 状態 |" in ja_region
+    assert "| **Alpha** | Alpha の仕事 | 公開 |" in ja_region
+    assert "| **Gamma** | Gamma の仕事 | 準備中 |" in ja_region
+
+
+def test_table_lint_failures():
+    missing_tagline = base_registry()
+    del missing_tagline["modules"][0]["tagline"]["th"]
+    failures = lint_registry(missing_tagline)
+    assert any(
+        "module 'alpha': tagline.th must be a string" in failure for failure in failures
+    )
+
+    missing_headers = base_registry()
+    del missing_headers["footer_text"]["table_what"]
+    del missing_headers["footer_text"]["table_state"]["zh"]
+    failures = lint_registry(missing_headers)
+    assert "registry/modules.json: footer_text.table_what must be an object" in failures
+    assert "registry/modules.json: footer_text.table_state.zh must be a string" in failures
+
+    invalid_tagline = base_registry()
+    invalid_tagline["modules"][0]["tagline"]["en"] = "Alpha | work"
+    try:
+        render_region(invalid_tagline, invalid_tagline["modules"][0], "en", "\n")
+    except FooterError as exc:
+        assert "tagline.en may not contain '|'" in str(exc)
+    else:
+        raise AssertionError("a pipe in a rendered tagline must fail closed")
+
+
 def test_check_rules():
     registry = base_registry()
 
     mismatch_registry = copy.deepcopy(registry)
     mismatch_registry["modules"][0]["footer"] = True
     good_region = render_region(mismatch_registry, mismatch_registry["modules"][0], "en", "\n")
-    bad_doc = document_with_region(good_region.replace("Siblings", "Siblingz", 1), "\n")
+    bad_doc = document_with_region(good_region.replace("Alpha work", "Alpha drift", 1), "\n")
     mismatch_fetch = lambda repo, filename: FetchResult("ok", bad_doc)
     failures, notes = check_registry_footers(mismatch_registry, fetcher=mismatch_fetch)
     assert any("footer content does not match the registry" in failure for failure in failures)
@@ -239,7 +330,14 @@ def test_render_idempotency_and_listing():
         assert "\r\n" in readme
         assert "[Beta](https://github.com/caty-ai/beta)" in readme
         assert "[Alpha](https://github.com/caty-ai/alpha)" not in readme
-        assert "Gamma" not in readme
+        assert "| **Alpha** | Alpha work | published |" in readme
+        assert "| **Gamma** | Gamma work | preparing |" in readme
+        assert "https://github.com/caty-ai/gamma" not in readme
+
+        ja_readme = (root / "README.ja.md").read_bytes().decode("utf-8")
+        assert "| モジュール | 何をするもの | 状態 |" in ja_readme
+        assert "| **Alpha** | Alpha の仕事 | 公開 |" in ja_readme
+        assert "| **Gamma** | Gamma の仕事 | 準備中 |" in ja_readme
 
         changed_again, changed_files_again = render_repo_to_target(
             registry, root, target_module["repo"]
@@ -254,6 +352,8 @@ def main() -> int:
         test_fence_tracker_edges,
         test_language_resolution,
         test_declared_set_resolution,
+        test_table_rendering,
+        test_table_lint_failures,
         test_check_rules,
         test_render_idempotency_and_listing,
     ]


### PR DESCRIPTION
Content amendment v3.1 of the family footer (#5): the sibling line becomes a full-module table — every module with a one-line tagline (registry data, all four languages, lint-required) and its state. Published modules linked; preparing modules and the host row named but deliberately unlinked, so the whole map is visible without shipping an intentional 404.

Enforcement machinery untouched — `git diff` on family_common / check_registry / render / CI is empty. Reviewed by two independent seats (both GO; one INFO + two LOW nits, all fail-closed direction).

After merge: `render-all` → five mechanical sibling PRs → same-day dispatch, per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)