### PR TITLE
Give the footer table the map's own shape: axis column, map row, structural order

### DIFF
--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -58,14 +58,14 @@ flowchart TB
 <!-- family:generated:module-inventory:start -->
 | モジュール | 種別 | 所有するもの | 状態 |
 | --- | --- | --- | --- |
+| [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | non-runtime・ガバナンス | Issue・PR・worktree・受け渡し・並行開発のルール | 公開・MIT |
 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | runtime・縦軸の基盤 | タスクの意味・試行・リトライ・チェックポイント・完了判定・完了・DLQ | 公開・MIT |
 | [Persona Engine](https://github.com/caty-ai/persona-engine) | runtime・単独利用可能 | 人格のレイヤーと感情のグラデーション | 公開・MIT |
-| [Sitter](https://github.com/caty-ai/sitter) | runtime・観測 | ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動 | 公開・MIT |
-| [X Collector](https://github.com/caty-ai/x-collector) | runtime・任意の入力 | 能力ループ向けの外部素材の収集 | 公開・MIT |
-| [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | non-runtime・ガバナンス | Issue・PR・worktree・受け渡し・並行開発のルール | 公開・MIT |
-| [Family Memory Architecture](https://github.com/shojikumaru/family-memory-architecture) | runtime・横方向の基盤 | 記憶バス・登録されたスケジュールの期待・check-in・来歴 | 公開準備中 |
-| [Self Growth Loop](https://github.com/shojikumaru/self-growth-loop) | runtime・アプリケーション | 提案・ガバナンス・採用記録・成長の解釈 | 公開準備中・基盤との接続は実装済み |
 | [Persona Growth Loop](https://github.com/shojikumaru/persona-growth-loop) | 計画中のフロントエンド | 最小化された冪等な提案の生成 | 公開準備中・計画中 |
+| [X Collector](https://github.com/caty-ai/x-collector) | runtime・任意の入力 | 能力ループ向けの外部素材の収集 | 公開・MIT |
+| [Self Growth Loop](https://github.com/shojikumaru/self-growth-loop) | runtime・アプリケーション | 提案・ガバナンス・採用記録・成長の解釈 | 公開準備中・基盤との接続は実装済み |
+| [Family Memory Architecture](https://github.com/shojikumaru/family-memory-architecture) | runtime・横方向の基盤 | 記憶バス・登録されたスケジュールの期待・check-in・来歴 | 公開準備中 |
+| [Sitter](https://github.com/caty-ai/sitter) | runtime・観測 | ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動 | 公開・MIT |
 <!-- family:generated:module-inventory:end -->
 
 この表は [`registry/modules.json`](../registry/modules.json) から生成しています。「公開準備中」のリンクは、いまはまだ開けません。何が存在し、どこに置かれるのかを地図として正直に保つために載せています。

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -58,14 +58,14 @@ The rules layer sits **above** both axes rather than inside either one. It is a 
 <!-- family:generated:module-inventory:start -->
 | Module | Class | Owns | State |
 | --- | --- | --- | --- |
+| [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | non-runtime governance | issue, PR, worktree, handoff, and parallel-development rules | published, MIT |
 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | runtime, vertical foundation | task meaning, attempt, retry, checkpoint, done-check, completion, dead-letter | published, MIT |
 | [Persona Engine](https://github.com/caty-ai/persona-engine) | runtime, standalone | persona layers and emotion gradation | published, MIT |
-| [Sitter](https://github.com/caty-ai/sitter) | runtime, observation | local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart | published, MIT |
-| [X Collector](https://github.com/caty-ai/x-collector) | runtime, optional input | collecting external material for the ability loop | published, MIT |
-| [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | non-runtime governance | issue, PR, worktree, handoff, and parallel-development rules | published, MIT |
-| [Family Memory Architecture](https://github.com/shojikumaru/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | publication in preparation |
-| [Self Growth Loop](https://github.com/shojikumaru/self-growth-loop) | runtime, application | proposal, governance, adoption records, growth interpretation | publication in preparation; harness link implemented |
 | [Persona Growth Loop](https://github.com/shojikumaru/persona-growth-loop) | planned frontend | minimised, idempotent proposal production | publication in preparation; planned |
+| [X Collector](https://github.com/caty-ai/x-collector) | runtime, optional input | collecting external material for the ability loop | published, MIT |
+| [Self Growth Loop](https://github.com/shojikumaru/self-growth-loop) | runtime, application | proposal, governance, adoption records, growth interpretation | publication in preparation; harness link implemented |
+| [Family Memory Architecture](https://github.com/shojikumaru/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | publication in preparation |
+| [Sitter](https://github.com/caty-ai/sitter) | runtime, observation | local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart | published, MIT |
 <!-- family:generated:module-inventory:end -->
 
 This table is generated from [`registry/modules.json`](../registry/modules.json). Links marked *publication in preparation* cannot be opened yet. They are listed so the map stays honest about what exists and where it will live.

--- a/docs/family-footer-contract.md
+++ b/docs/family-footer-contract.md
@@ -2,7 +2,7 @@
 
 The family footer is one generated region per declared root `README*.md` in sibling repositories. Literal generated marker lines may appear in documentation only inside fenced code blocks.
 
-The v3.1 content amendment replaces v3's sibling list with a full-module table. Marker parsing, declared files, byte-exact comparison, and all four enforcement rules are unchanged.
+The v3.2 content amendment adds the Family OS map row and a leading axis column to the full-module table. Marker parsing, declared files, byte-exact comparison, and all four enforcement rules are unchanged.
 
 ## Markers
 
@@ -13,11 +13,12 @@ The v3.1 content amendment replaces v3's sibling list with a full-module table. 
 
 {intro with {map} replaced by [Family OS](https://github.com/<map_repo>)}
 
-| Module | What it does | State |
-| --- | --- | --- |
-| **Host Module** | {tagline for this language} | {status label for this language} |
-| [Published Module](https://github.com/<repo>) | {tagline for this language} | {status label for this language} |
-| **Preparing Module** | {tagline for this language} | {status label for this language} |
+| Axis | Module | What it does | State |
+| --- | --- | --- | --- |
+| Map | [Family OS](https://github.com/<map_repo>) | {map tagline for this language} | {published status label for this language} |
+| Rules | **Host Module** | {tagline for this language} | {status label for this language} |
+| Vertical · foundation | [Published Foundation](https://github.com/<repo>) | {tagline for this language} | {status label for this language} |
+| Horizontal | **Preparing Module** | {tagline for this language} | {status label for this language} |
 
 <!-- family:generated:family-footer:end -->
 ```
@@ -28,12 +29,16 @@ The v3.1 content amendment replaces v3's sibling list with a full-module table. 
 
 ## Content
 
-- The table contains every registry module in registry order, including modules still being prepared and the repository hosting the footer.
+- The first data row is always the Family OS map. Its name is always linked to `https://github.com/<map_repo>`, including when there is no host module to exclude. Its axis label, localized tagline, and published state come from `footer_text.axis_map`, `footer_text.map_tagline`, and `status_labels.published`; its uniform display name comes from `footer_text.map_name`.
+- The remaining rows contain every registry module in registry order, including modules still being prepared and the repository hosting the footer. Registry order is the display order: it encodes rules first, then the vertical axis with its foundation first, then the horizontal axis with its foundation first.
+- Each module declares `axis.group` as `rules`, `vertical`, or `horizontal`, and `axis.foundation` as a boolean. The localized axis cell comes from `footer_text.axis_rules`, `footer_text.axis_vertical`, or `footer_text.axis_horizontal`; a true foundation flag appends `footer_text.axis_foundation_suffix`.
+- The axis column mirrors the Family OS three-layer structure: rules sit above the vertical and horizontal axes beneath them. The map row represents the whole structure rather than one of those module layers.
 - A published module name links to its repository, except that the host row is bold and unlinked. A preparing module name is also bold and unlinked, so the footer shows the full map without shipping an intentional `404` link.
 - The localized description comes from the module's required `tagline` registry field. Every tagline must define every registry language.
 - The localized state comes directly from `status_labels`; module `note` fields are not rendered.
-- The three localized headers come from `footer_text.table_module`, `footer_text.table_what`, and `footer_text.table_state`.
-- Header, module-name, tagline, and status-label cells fail validation if they contain a pipe or newline, rather than emitting a malformed Markdown table.
+- The four localized headers come from `footer_text.table_axis`, `footer_text.table_module`, `footer_text.table_what`, and `footer_text.table_state`.
+- Every new `footer_text` section (`table_axis`, `map_name`, `axis_map`, `axis_rules`, `axis_vertical`, `axis_horizontal`, `axis_foundation_suffix`, and `map_tagline`) must define every registry language.
+- Header, axis, map-name, module-name, tagline, and status-label cells fail validation if they contain a pipe or newline, rather than emitting a malformed Markdown table.
 
 ## Declared Files
 

--- a/docs/readme-visual-system.md
+++ b/docs/readme-visual-system.md
@@ -124,14 +124,14 @@ module means editing that file; every generated block in every language follows.
 <!-- family:generated:repository-links:start -->
 | Module | Link target | State |
 | --- | --- | --- |
+| Family Dev Handbook | `caty-ai/family-dev-handbook` | published, MIT |
 | Caty Agent Harness | `caty-ai/caty-agent-harness` | published, MIT |
 | Persona Engine | `caty-ai/persona-engine` | published, MIT |
-| Sitter | `caty-ai/sitter` | published, MIT |
-| X Collector | `caty-ai/x-collector` | published, MIT |
-| Family Dev Handbook | `caty-ai/family-dev-handbook` | published, MIT |
-| Family Memory Architecture | `shojikumaru/family-memory-architecture` | publication in preparation |
-| Self Growth Loop | `shojikumaru/self-growth-loop` | publication in preparation; harness link implemented |
 | Persona Growth Loop | `shojikumaru/persona-growth-loop` | publication in preparation; planned |
+| X Collector | `caty-ai/x-collector` | published, MIT |
+| Self Growth Loop | `shojikumaru/self-growth-loop` | publication in preparation; harness link implemented |
+| Family Memory Architecture | `shojikumaru/family-memory-architecture` | publication in preparation |
+| Sitter | `caty-ai/sitter` | published, MIT |
 <!-- family:generated:repository-links:end -->
 
 ### Superseded v3 map rules

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -15,6 +15,12 @@
       "zh": "本仓库属于 **Caty AI 家族** — 用于运营 AI 智能体家族的开源工具集。完整地图（包括仍在准备公开的模块）见 {map}。",
       "th": "รีโพนี้เป็นส่วนหนึ่งของ **ครอบครัว Caty AI** — ชุดเครื่องมือโอเพนซอร์สสำหรับดูแลครอบครัวเอเจนต์ AI แผนที่ฉบับเต็ม (รวมโมดูลที่กำลังเตรียมเปิด) อยู่ที่ {map}"
     },
+    "table_axis": {
+      "en": "Axis",
+      "ja": "軸",
+      "zh": "轴",
+      "th": "แกน"
+    },
     "table_module": {
       "en": "Module",
       "ja": "モジュール",
@@ -32,6 +38,48 @@
       "ja": "状態",
       "zh": "状态",
       "th": "สถานะ"
+    },
+    "map_name": {
+      "en": "Family OS",
+      "ja": "Family OS",
+      "zh": "Family OS",
+      "th": "Family OS"
+    },
+    "axis_map": {
+      "en": "Map",
+      "ja": "地図",
+      "zh": "地图",
+      "th": "แผนที่"
+    },
+    "axis_rules": {
+      "en": "Rules",
+      "ja": "掟",
+      "zh": "规则",
+      "th": "กติกา"
+    },
+    "axis_vertical": {
+      "en": "Vertical",
+      "ja": "縦軸",
+      "zh": "纵轴",
+      "th": "แกนตั้ง"
+    },
+    "axis_horizontal": {
+      "en": "Horizontal",
+      "ja": "横軸",
+      "zh": "横轴",
+      "th": "แกนนอน"
+    },
+    "axis_foundation_suffix": {
+      "en": " · foundation",
+      "ja": "・基盤",
+      "zh": "・基座",
+      "th": " · รากฐาน"
+    },
+    "map_tagline": {
+      "en": "The map of the whole family — every module, its state, and how they fit",
+      "ja": "AIファミリー全体の地図 — モジュール・状態・つながり",
+      "zh": "整个家族的地图 — 模块、状态与结构",
+      "th": "แผนที่ของทั้งครอบครัว — โมดูล สถานะ และโครงสร้าง"
     }
   },
   "note_separator": {
@@ -56,6 +104,32 @@
   },
   "modules": [
     {
+      "id": "family-dev-handbook",
+      "name": "Family Dev Handbook",
+      "repo": "caty-ai/family-dev-handbook",
+      "status": "published",
+      "tagline": {
+        "en": "The rules of the road — issues, PRs, worktrees, handoffs, parallel development",
+        "ja": "開発の交通ルール — Issue・PR・worktree・受け渡し・並行開発",
+        "zh": "开发的交通规则 — Issue、PR、worktree、交接与并行开发",
+        "th": "กติกากลางของการพัฒนา — Issue, PR, worktree, การส่งงานต่อ และการทำงานคู่ขนาน"
+      },
+      "axis": {
+        "group": "rules",
+        "foundation": false
+      },
+      "license": "MIT",
+      "class": {
+        "en": "non-runtime governance",
+        "ja": "non-runtime・ガバナンス"
+      },
+      "owns": {
+        "en": "issue, PR, worktree, handoff, and parallel-development rules",
+        "ja": "Issue・PR・worktree・受け渡し・並行開発のルール"
+      },
+      "footer": true
+    },
+    {
       "id": "caty-agent-harness",
       "name": "Caty Agent Harness",
       "repo": "caty-ai/caty-agent-harness",
@@ -65,6 +139,10 @@
         "ja": "AIエージェントのタスク基盤 — 試行・リトライ・チェックポイント・完了判定",
         "zh": "AI 智能体的任务基座 — 重试、检查点与完成判定",
         "th": "แกนงานของเอเจนต์ AI — การลองใหม่ เช็คพอยต์ และการตัดสินว่าเสร็จจริง"
+      },
+      "axis": {
+        "group": "vertical",
+        "foundation": true
       },
       "license": "MIT",
       "class": {
@@ -88,6 +166,10 @@
         "zh": "为智能体赋予人格 — 分层人格与情感渐变",
         "th": "มอบบุคลิกให้เอเจนต์ — เลเยอร์บุคลิกและอารมณ์แบบไล่ระดับ"
       },
+      "axis": {
+        "group": "vertical",
+        "foundation": false
+      },
       "readme_overrides": {
         "README.zh-CN.md": "zh"
       },
@@ -103,26 +185,33 @@
       "footer": true
     },
     {
-      "id": "sitter",
-      "name": "Sitter",
-      "repo": "caty-ai/sitter",
-      "status": "published",
+      "id": "persona-growth-loop",
+      "name": "Persona Growth Loop",
+      "repo": "shojikumaru/persona-growth-loop",
+      "status": "preparing",
       "tagline": {
-        "en": "Babysits delegated agent runs — watches, keeps evidence, restarts",
-        "ja": "委譲したエージェント実行の見張り番 — 監視・証拠の記録・再起動",
-        "zh": "替你盯着委派出去的智能体 — 监视、留证、重启",
-        "th": "พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ต"
+        "en": "Grows the persona itself — minimal, idempotent proposals",
+        "ja": "人格そのものを育てる — 最小・冪等な提案づくり",
+        "zh": "让人格本身成长 — 以最小且幂等的提案",
+        "th": "พัฒนาบุคลิกของเอเจนต์ — สร้างข้อเสนอแบบน้อยที่สุดและทำซ้ำได้"
       },
-      "license": "MIT",
+      "axis": {
+        "group": "vertical",
+        "foundation": false
+      },
+      "license": null,
       "class": {
-        "en": "runtime, observation",
-        "ja": "runtime・観測"
+        "en": "planned frontend",
+        "ja": "計画中のフロントエンド"
       },
       "owns": {
-        "en": "local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart",
-        "ja": "ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動"
+        "en": "minimised, idempotent proposal production",
+        "ja": "最小化された冪等な提案の生成"
       },
-      "footer": true
+      "note": {
+        "en": "planned",
+        "ja": "計画中"
+      }
     },
     {
       "id": "x-collector",
@@ -134,6 +223,10 @@
         "ja": "Xやウェブの素材を1日1回のダイジェストに — 人にもエージェントにも",
         "zh": "把 X 与网络素材汇成每日一份摘要 — 给人也给智能体",
         "th": "รวบรวมข้อมูลจาก X และเว็บเป็นสรุปวันละฉบับ — สำหรับคนและเอเจนต์"
+      },
+      "axis": {
+        "group": "vertical",
+        "foundation": false
       },
       "license": "MIT",
       "class": {
@@ -147,49 +240,6 @@
       "footer": true
     },
     {
-      "id": "family-dev-handbook",
-      "name": "Family Dev Handbook",
-      "repo": "caty-ai/family-dev-handbook",
-      "status": "published",
-      "tagline": {
-        "en": "The rules of the road — issues, PRs, worktrees, handoffs, parallel development",
-        "ja": "開発の交通ルール — Issue・PR・worktree・受け渡し・並行開発",
-        "zh": "开发的交通规则 — Issue、PR、worktree、交接与并行开发",
-        "th": "กติกากลางของการพัฒนา — Issue, PR, worktree, การส่งงานต่อ และการทำงานคู่ขนาน"
-      },
-      "license": "MIT",
-      "class": {
-        "en": "non-runtime governance",
-        "ja": "non-runtime・ガバナンス"
-      },
-      "owns": {
-        "en": "issue, PR, worktree, handoff, and parallel-development rules",
-        "ja": "Issue・PR・worktree・受け渡し・並行開発のルール"
-      },
-      "footer": true
-    },
-    {
-      "id": "family-memory-architecture",
-      "name": "Family Memory Architecture",
-      "repo": "shojikumaru/family-memory-architecture",
-      "status": "preparing",
-      "tagline": {
-        "en": "The memory bus — how the family shares what it knows",
-        "ja": "記憶バス — 家族が知っていることを共有する層",
-        "zh": "记忆总线 — 家族共享所知的一层",
-        "th": "บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้"
-      },
-      "license": null,
-      "class": {
-        "en": "runtime, horizontal infrastructure",
-        "ja": "runtime・横方向の基盤"
-      },
-      "owns": {
-        "en": "the memory bus; registered schedule expectation, check-in, provenance",
-        "ja": "記憶バス・登録されたスケジュールの期待・check-in・来歴"
-      }
-    },
-    {
       "id": "self-growth-loop",
       "name": "Self Growth Loop",
       "repo": "shojikumaru/self-growth-loop",
@@ -199,6 +249,10 @@
         "ja": "エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録",
         "zh": "让智能体自我成长的循环 — 提案、治理与采用记录",
         "th": "วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง — ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้"
+      },
+      "axis": {
+        "group": "vertical",
+        "foundation": false
       },
       "license": null,
       "class": {
@@ -215,29 +269,55 @@
       }
     },
     {
-      "id": "persona-growth-loop",
-      "name": "Persona Growth Loop",
-      "repo": "shojikumaru/persona-growth-loop",
+      "id": "family-memory-architecture",
+      "name": "Family Memory Architecture",
+      "repo": "shojikumaru/family-memory-architecture",
       "status": "preparing",
       "tagline": {
-        "en": "Grows the persona itself — minimal, idempotent proposals",
-        "ja": "人格そのものを育てる — 最小・冪等な提案づくり",
-        "zh": "让人格本身成长 — 以最小且幂等的提案",
-        "th": "พัฒนาบุคลิกของเอเจนต์ — สร้างข้อเสนอแบบน้อยที่สุดและทำซ้ำได้"
+        "en": "The memory bus — how the family shares what it knows",
+        "ja": "記憶バス — 家族が知っていることを共有する層",
+        "zh": "记忆总线 — 家族共享所知的一层",
+        "th": "บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้"
+      },
+      "axis": {
+        "group": "horizontal",
+        "foundation": true
       },
       "license": null,
       "class": {
-        "en": "planned frontend",
-        "ja": "計画中のフロントエンド"
+        "en": "runtime, horizontal infrastructure",
+        "ja": "runtime・横方向の基盤"
       },
       "owns": {
-        "en": "minimised, idempotent proposal production",
-        "ja": "最小化された冪等な提案の生成"
-      },
-      "note": {
-        "en": "planned",
-        "ja": "計画中"
+        "en": "the memory bus; registered schedule expectation, check-in, provenance",
+        "ja": "記憶バス・登録されたスケジュールの期待・check-in・来歴"
       }
+    },
+    {
+      "id": "sitter",
+      "name": "Sitter",
+      "repo": "caty-ai/sitter",
+      "status": "published",
+      "tagline": {
+        "en": "Babysits delegated agent runs — watches, keeps evidence, restarts",
+        "ja": "委譲したエージェント実行の見張り番 — 監視・証拠の記録・再起動",
+        "zh": "替你盯着委派出去的智能体 — 监视、留证、重启",
+        "th": "พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ต"
+      },
+      "axis": {
+        "group": "horizontal",
+        "foundation": false
+      },
+      "license": "MIT",
+      "class": {
+        "en": "runtime, observation",
+        "ja": "runtime・観測"
+      },
+      "owns": {
+        "en": "local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart",
+        "ja": "ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動"
+      },
+      "footer": true
     }
   ],
   "retired_repos": [

--- a/tools/family_footer.py
+++ b/tools/family_footer.py
@@ -195,7 +195,20 @@ def lint_registry(registry: dict) -> List[str]:
     if not isinstance(footer_text, dict):
         failures.append("registry/modules.json: footer_text must be an object")
     else:
-        for key in ("intro", "table_module", "table_what", "table_state"):
+        for key in (
+            "intro",
+            "table_axis",
+            "table_module",
+            "table_what",
+            "table_state",
+            "map_name",
+            "axis_map",
+            "axis_rules",
+            "axis_vertical",
+            "axis_horizontal",
+            "axis_foundation_suffix",
+            "map_tagline",
+        ):
             section = footer_text.get(key)
             if not isinstance(section, dict):
                 failures.append("registry/modules.json: footer_text.%s must be an object" % key)
@@ -260,6 +273,16 @@ def lint_registry(registry: dict) -> List[str]:
         status = module.get("status")
         if status not in status_labels:
             failures.append("%s: status must name an entry in status_labels" % label)
+        axis = module.get("axis")
+        if not isinstance(axis, dict):
+            failures.append("%s: axis must be an object" % label)
+        else:
+            if axis.get("group") not in {"rules", "vertical", "horizontal"}:
+                failures.append(
+                    "%s: axis.group must be one of rules, vertical, horizontal" % label
+                )
+            if not isinstance(axis.get("foundation"), bool):
+                failures.append("%s: axis.foundation must be a boolean" % label)
         if "footer" in module and not isinstance(module["footer"], bool):
             failures.append("%s: footer must be a boolean when present" % label)
         if footer_enabled(module) and module.get("status") != "published":
@@ -272,13 +295,28 @@ def lint_registry(registry: dict) -> List[str]:
     return failures
 
 
-def map_link(registry: dict) -> str:
-    return "[Family OS](https://github.com/%s)" % registry["map_repo"]
+def map_link(registry: dict, lang: str) -> str:
+    return "[%s](https://github.com/%s)" % (
+        registry["footer_text"]["map_name"][lang],
+        registry["map_repo"],
+    )
 
 
-def module_table(registry: dict, host_module: dict, lang: str, newline: str) -> str:
+def module_axis(registry: dict, module: dict, lang: str) -> str:
+    axis = module["axis"]
+    value = registry["footer_text"]["axis_%s" % axis["group"]][lang]
+    if axis["foundation"]:
+        value += registry["footer_text"]["axis_foundation_suffix"][lang]
+    validate_table_cell_value("%s axis.%s" % (module_label(module), lang), value)
+    return value
+
+
+def module_table(
+    registry: dict, host_module: Optional[dict], lang: str, newline: str
+) -> str:
     footer_text = registry["footer_text"]
     headers = [
+        ("table_axis", footer_text["table_axis"][lang]),
         ("table_module", footer_text["table_module"][lang]),
         ("table_what", footer_text["table_what"][lang]),
         ("table_state", footer_text["table_state"][lang]),
@@ -287,10 +325,23 @@ def module_table(registry: dict, host_module: dict, lang: str, newline: str) -> 
         validate_table_cell_value("footer_text.%s.%s" % (key, lang), value)
 
     rows = [
-        "| %s | %s | %s |" % tuple(value for _key, value in headers),
-        "| --- | --- | --- |",
+        "| %s | %s | %s | %s |" % tuple(value for _key, value in headers),
+        "| --- | --- | --- | --- |",
     ]
+    map_axis = footer_text["axis_map"][lang]
+    map_name = footer_text["map_name"][lang]
+    map_tagline = footer_text["map_tagline"][lang]
+    map_status = registry["status_labels"]["published"][lang]
+    validate_table_cell_value("footer_text.axis_map.%s" % lang, map_axis)
+    validate_table_cell_value("footer_text.map_name.%s" % lang, map_name)
+    validate_table_cell_value("footer_text.map_tagline.%s" % lang, map_tagline)
+    validate_table_cell_value("status_labels.published.%s" % lang, map_status)
+    rows.append(
+        "| %s | %s | %s | %s |"
+        % (map_axis, map_link(registry, lang), map_tagline, map_status)
+    )
     for module in registry["modules"]:
+        axis = module_axis(registry, module, lang)
         name = module["name"]
         tagline = module["tagline"][lang]
         status = registry["status_labels"][module["status"]][lang]
@@ -300,16 +351,21 @@ def module_table(registry: dict, host_module: dict, lang: str, newline: str) -> 
             "status_labels.%s.%s" % (module["status"], lang), status
         )
 
-        if module["repo"] == host_module["repo"] or module["status"] != "published":
+        is_host = host_module is not None and module["repo"] == host_module["repo"]
+        if is_host or module["status"] != "published":
             rendered_name = "**%s**" % name
         else:
             rendered_name = "[%s](https://github.com/%s)" % (name, module["repo"])
-        rows.append("| %s | %s | %s |" % (rendered_name, tagline, status))
+        rows.append("| %s | %s | %s | %s |" % (axis, rendered_name, tagline, status))
     return newline.join(rows)
 
 
-def render_region(registry: dict, module: dict, lang: str, newline: str) -> str:
-    intro = registry["footer_text"]["intro"][lang].replace("{map}", map_link(registry))
+def render_region(
+    registry: dict, module: Optional[dict], lang: str, newline: str
+) -> str:
+    intro = registry["footer_text"]["intro"][lang].replace(
+        "{map}", map_link(registry, lang)
+    )
     table = module_table(registry, module, lang, newline)
     return (
         newline

--- a/tools/selftest_family_footer.py
+++ b/tools/selftest_family_footer.py
@@ -33,6 +33,12 @@ def base_registry():
                 "zh": "Intro {map}.",
                 "th": "Intro {map}.",
             },
+            "table_axis": {
+                "en": "Axis",
+                "ja": "軸",
+                "zh": "轴",
+                "th": "แกน",
+            },
             "table_module": {
                 "en": "Module",
                 "ja": "モジュール",
@@ -50,6 +56,48 @@ def base_registry():
                 "ja": "状態",
                 "zh": "状态",
                 "th": "สถานะ",
+            },
+            "map_name": {
+                "en": "Family OS",
+                "ja": "Family OS",
+                "zh": "Family OS",
+                "th": "Family OS",
+            },
+            "axis_map": {
+                "en": "Map",
+                "ja": "地図",
+                "zh": "地图",
+                "th": "แผนที่",
+            },
+            "axis_rules": {
+                "en": "Rules",
+                "ja": "掟",
+                "zh": "规则",
+                "th": "กติกา",
+            },
+            "axis_vertical": {
+                "en": "Vertical",
+                "ja": "縦軸",
+                "zh": "纵轴",
+                "th": "แกนตั้ง",
+            },
+            "axis_horizontal": {
+                "en": "Horizontal",
+                "ja": "横軸",
+                "zh": "横轴",
+                "th": "แกนนอน",
+            },
+            "axis_foundation_suffix": {
+                "en": " · foundation",
+                "ja": "・基盤",
+                "zh": "・基座",
+                "th": " · รากฐาน",
+            },
+            "map_tagline": {
+                "en": "The family map",
+                "ja": "ファミリーの地図",
+                "zh": "家族地图",
+                "th": "แผนที่ครอบครัว",
             },
         },
         "status_labels": {
@@ -78,6 +126,7 @@ def base_registry():
                     "zh": "Alpha 的工作",
                     "th": "งานของ Alpha",
                 },
+                "axis": {"group": "rules", "foundation": False},
             },
             {
                 "id": "beta",
@@ -90,6 +139,7 @@ def base_registry():
                     "zh": "Beta 的工作",
                     "th": "งานของ Beta",
                 },
+                "axis": {"group": "vertical", "foundation": True},
                 "readme_overrides": {"README.zh-CN.md": "zh"},
             },
             {
@@ -103,6 +153,7 @@ def base_registry():
                     "zh": "Gamma 的工作",
                     "th": "งานของ Gamma",
                 },
+                "axis": {"group": "horizontal", "foundation": False},
             },
         ],
         "retired_repos": [],
@@ -235,19 +286,46 @@ def test_table_rendering():
     region = render_region(registry, registry["modules"][0], "en", "\n")
     table_lines = [line for line in region.splitlines() if line.startswith("|")]
     assert table_lines == [
-        "| Module | What it does | State |",
-        "| --- | --- | --- |",
-        "| **Alpha** | Alpha work | published |",
-        "| [Beta](https://github.com/caty-ai/beta) | Beta work | published |",
-        "| **Gamma** | Gamma work | preparing |",
+        "| Axis | Module | What it does | State |",
+        "| --- | --- | --- | --- |",
+        "| Map | [Family OS](https://github.com/caty-ai/family-os) | The family map | published |",
+        "| Rules | **Alpha** | Alpha work | published |",
+        "| Vertical · foundation | [Beta](https://github.com/caty-ai/beta) | Beta work | published |",
+        "| Horizontal | **Gamma** | Gamma work | preparing |",
     ]
     assert "https://github.com/caty-ai/alpha" not in region
     assert "https://github.com/caty-ai/gamma" not in region
 
     ja_region = render_region(registry, registry["modules"][0], "ja", "\n")
-    assert "| モジュール | 何をするもの | 状態 |" in ja_region
-    assert "| **Alpha** | Alpha の仕事 | 公開 |" in ja_region
-    assert "| **Gamma** | Gamma の仕事 | 準備中 |" in ja_region
+    assert "| 軸 | モジュール | 何をするもの | 状態 |" in ja_region
+    assert "| 地図 | [Family OS](https://github.com/caty-ai/family-os) | ファミリーの地図 | 公開 |" in ja_region
+    assert "| 掟 | **Alpha** | Alpha の仕事 | 公開 |" in ja_region
+    assert "| 縦軸・基盤 | [Beta](https://github.com/caty-ai/beta) | Beta の仕事 | 公開 |" in ja_region
+    assert "| 横軸 | **Gamma** | Gamma の仕事 | 準備中 |" in ja_region
+
+
+def test_map_row_and_registry_ordering():
+    registry = base_registry()
+    for host in registry["modules"] + [None]:
+        region = render_region(registry, host, "en", "\n")
+        data_rows = [
+            line
+            for line in region.splitlines()
+            if line.startswith("|") and not line.startswith("| ---")
+        ][1:]
+        assert data_rows[0].startswith(
+            "| Map | [Family OS](https://github.com/caty-ai/family-os) |"
+        )
+
+    reordered = copy.deepcopy(registry)
+    reordered["modules"] = [
+        reordered["modules"][2],
+        reordered["modules"][0],
+        reordered["modules"][1],
+    ]
+    region = render_region(reordered, reordered["modules"][0], "en", "\n")
+    assert region.index("| Horizontal | **Gamma**") < region.index("| Rules | [Alpha]")
+    assert region.index("| Rules | [Alpha]") < region.index("| Vertical · foundation | [Beta]")
 
 
 def test_table_lint_failures():
@@ -273,6 +351,26 @@ def test_table_lint_failures():
         assert "tagline.en may not contain '|'" in str(exc)
     else:
         raise AssertionError("a pipe in a rendered tagline must fail closed")
+
+    missing_axis = base_registry()
+    del missing_axis["modules"][0]["axis"]
+    failures = lint_registry(missing_axis)
+    assert "registry/modules.json: module 'alpha': axis must be an object" in failures
+
+    bad_axis_group = base_registry()
+    bad_axis_group["modules"][0]["axis"]["group"] = "diagonal"
+    failures = lint_registry(bad_axis_group)
+    assert any("axis.group must be one of" in failure for failure in failures)
+
+    missing_axis_language = base_registry()
+    del missing_axis_language["footer_text"]["axis_vertical"]["ja"]
+    failures = lint_registry(missing_axis_language)
+    assert "registry/modules.json: footer_text.axis_vertical.ja must be a string" in failures
+
+    invalid_axis_label = base_registry()
+    invalid_axis_label["footer_text"]["axis_rules"]["en"] = "Rules | policy"
+    failures = lint_registry(invalid_axis_label)
+    assert "registry/modules.json: footer_text.axis_rules.en may not contain '|'" in failures
 
 
 def test_check_rules():
@@ -330,14 +428,16 @@ def test_render_idempotency_and_listing():
         assert "\r\n" in readme
         assert "[Beta](https://github.com/caty-ai/beta)" in readme
         assert "[Alpha](https://github.com/caty-ai/alpha)" not in readme
-        assert "| **Alpha** | Alpha work | published |" in readme
-        assert "| **Gamma** | Gamma work | preparing |" in readme
+        assert "| Map | [Family OS](https://github.com/caty-ai/family-os) |" in readme
+        assert "| Rules | **Alpha** | Alpha work | published |" in readme
+        assert "| Horizontal | **Gamma** | Gamma work | preparing |" in readme
         assert "https://github.com/caty-ai/gamma" not in readme
 
         ja_readme = (root / "README.ja.md").read_bytes().decode("utf-8")
-        assert "| モジュール | 何をするもの | 状態 |" in ja_readme
-        assert "| **Alpha** | Alpha の仕事 | 公開 |" in ja_readme
-        assert "| **Gamma** | Gamma の仕事 | 準備中 |" in ja_readme
+        assert "| 軸 | モジュール | 何をするもの | 状態 |" in ja_readme
+        assert "| 地図 | [Family OS](https://github.com/caty-ai/family-os) |" in ja_readme
+        assert "| 掟 | **Alpha** | Alpha の仕事 | 公開 |" in ja_readme
+        assert "| 横軸 | **Gamma** | Gamma の仕事 | 準備中 |" in ja_readme
 
         changed_again, changed_files_again = render_repo_to_target(
             registry, root, target_module["repo"]
@@ -353,6 +453,7 @@ def main() -> int:
         test_language_resolution,
         test_declared_set_resolution,
         test_table_rendering,
+        test_map_row_and_registry_ordering,
         test_table_lint_failures,
         test_check_rules,
         test_render_idempotency_and_listing,


### PR DESCRIPTION
Content amendment v3.2 (owner-directed): the footer table now mirrors the Family OS three-layer structure — the map itself as the always-linked first row, the rules above everything, then the vertical axis (foundation first) and the horizontal axis (foundation first), with a leading Axis column saying where each module belongs. The registry's module order now encodes the structure; the engineering inventory tables are regenerated accordingly in this PR.

Machinery untouched (empty diff on family_common / check_registry / render.py code / CI). Two independent review seats: both GO, zero findings (one verified the regenerated docs are pure render output — write-mode re-run produces zero further diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)