### PR TITLE
chore: enable family footer for FMA

### DIFF
--- a/registry/modules.json
+++ b/registry/modules.json
@@ -316,7 +316,8 @@
       "owns": {
         "en": "the memory bus; registered schedule expectation, check-in, provenance",
         "ja": "記憶バス・登録されたスケジュールの期待・check-in・来歴"
-      }
+      },
+      "footer": true
     },
     {
       "id": "sitter",


### PR DESCRIPTION
`tools/family_footer.py check` fails on main with **caty-ai/family-memory-architecture: published module has no footer** — FMA was marked published (`35b4392`) without enabling its footer flag. This sets `footer: true`; the footer itself is rendered into the FMA repo in a companion PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)