### PR TITLE
registry: self-growth-loop is published (caty-ai/self-growth-loop, MIT)

### DIFF
--- a/registry/modules.json
+++ b/registry/modules.json
@@ -268,8 +268,8 @@
     {
       "id": "self-growth-loop",
       "name": "Self Growth Loop",
-      "repo": "shojikumaru/self-growth-loop",
-      "status": "preparing",
+      "repo": "caty-ai/self-growth-loop",
+      "status": "published",
       "tagline": {
         "en": "Lets an agent grow its own abilities — proposals, governance, adoption records",
         "ja": "エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録",
@@ -280,7 +280,7 @@
         "group": "vertical",
         "foundation": false
       },
-      "license": null,
+      "license": "MIT",
       "class": {
         "en": "runtime, application",
         "ja": "runtime・アプリケーション"
@@ -289,10 +289,7 @@
         "en": "proposal, governance, adoption records, growth interpretation",
         "ja": "提案・ガバナンス・採用記録・成長の解釈"
       },
-      "note": {
-        "en": "harness link implemented",
-        "ja": "基盤との接続は実装済み"
-      }
+      "footer": true
     },
     {
       "id": "family-memory-architecture",


### PR DESCRIPTION
Closes #19

- `repo`: shojikumaru/self-growth-loop → **caty-ai/self-growth-loop** (published today, fresh-history v0.1.0)
- `status`: preparing → **published** / `license`: **MIT** / `footer`: **true**
- `note` removed (not rendered in footers; superseded by publication)

Validation: `tools/check_registry.py` → OK (reality check green) / `tools/selftest_family_footer.py` → OK

Follow-up after merge (per docs/family-footer-contract.md): footer sync commits across published siblings + SGL README gains its footer block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)