### PR TITLE
org-profile-modules: render the org profile module list from the registry (PR 1/3 for #21)

### DIFF
--- a/docs/family-footer-contract.md
+++ b/docs/family-footer-contract.md
@@ -2,7 +2,7 @@
 
 The family footer is one generated region per declared root `README*.md` in sibling repositories. Literal generated marker lines may appear in documentation only inside fenced code blocks.
 
-The v3.2 content amendment adds the Family OS map row and a leading axis column to the full-module table. The v3.3 amendment fixes the block's placement (below, trialled on sitter and owner-approved). The v3.4 amendment lets the map repository render the same table into its own README (the `family-table` block) with the map row bold and unlinked — member-repo footers are unchanged. The v3.5 amendment allows a repository with a hand-written family section to host the block inside that section — heading, member prose, generated table, then connecting prose (owner-approved, first applied on FMA); the byte-exact comparison is position-independent either way. Marker parsing, declared files, byte-exact comparison, and all four enforcement rules are unchanged.
+The v3.2 content amendment adds the Family OS map row and a leading axis column to the full-module table. The v3.3 amendment fixes the block's placement (below, trialled on sitter and owner-approved). The v3.4 amendment lets the map repository render the same table into its own README (the `family-table` block) with the map row bold and unlinked — member-repo footers are unchanged. The v3.5 amendment allows a repository with a hand-written family section to host the block inside that section — heading, member prose, generated table, then connecting prose (owner-approved, first applied on FMA); the byte-exact comparison is position-independent either way. The v3.6 amendment adds the separately enforced `org-profile-modules` block for the caty-ai organization profile. Existing member-footer rendering and enforcement remain unchanged.
 
 ## Markers
 
@@ -71,6 +71,67 @@ The weekly content check reads every declared README of every published module, 
 - Sibling-first ordering is mandatory. Flip-first makes the scheduled check fail immediately on `footer:true` plus missing markers, while sibling-first is only stale until the flag PR closes the rollout.
 - The rollout window is deliberately red after Epic #0 merges and before the flag flip PR lands. That red state is the reminder that the map and the published siblings are still being brought into sync.
 
+## v3.6 Organization Profile Amendment
+
+The org profile uses a second block id, `org-profile-modules`, owned by `tools/family_footer.py`. It renders the localized ecosystem intro and the complete bullet list from `registry/modules.json`: the Family OS map first, then every module in registry order. Published module names link to the module's declared `repo`; preparing names remain bold and unlinked. The open count is rendered as digits and is always the number of published modules plus one for the map.
+
+```html
+<!-- family:generated:org-profile-modules:start -->
+
+{localized ecosystem intro with {count} replaced by digits}
+
+- **[Family OS](https://github.com/<map_repo>)** — {localized map description}{localized published label}
+- **[Published module](https://github.com/<module repo>)** — {localized description}{localized published label}
+- **Preparing module** — {localized description}{localized preparing label}
+
+<!-- family:generated:org-profile-modules:end -->
+```
+
+Like the member footer, the bytes inside the org region start and end with a blank line, and the start marker's newline style is preserved. Unlike the member footer, the region has no horizontal-rule separator. Each checking or rendering pass recognizes exactly one block id; a live marker for the other id in a checked file is a hard error.
+
+### Declared org files and placement
+
+The declared org-profile paths are a closed, ordered set. Both English files are independent verification targets and may not be collapsed:
+
+1. `profile/README.md` → `en`
+2. `README.md` → `en`
+3. `README.ja.md` → `ja`
+4. `README.zh.md` → `zh`
+5. `README.th.md` → `th`
+
+Every path must additionally pass `re.fullmatch(r'(?:profile/)?README(?:\.[A-Za-z0-9-]+)?\.md', path)`. Leading slashes, `..` segments, backslashes, percent encoding, and whitespace are rejected explicitly. The pattern validates shape; equality with the closed set validates identity. A local `render-org --stray-scan` walks the full checkout except `.git` and rejects any org marker outside these five paths.
+
+The block sits inside the profile's collapsed `<details>` text version. Its intro sentence is inside the generated region. The whole region occupies the ecosystem-list position above the “With any agent…” paragraph; it is not appended to the file and is not placed outside the details element. `render-org` never inserts markers: all five marker pairs must already exist.
+
+### Org enforcement rules R1–R4
+
+The weekly check visits every declared org file in the order above and applies these rules independently:
+
+1. **R1:** markers present and `enforced:false` fails with `org profile block exists but is not enforced`.
+2. **R2:** markers present and `enforced:true` requires byte-exact registry output in every declared file; mismatches name the file.
+3. **R3:** markers missing from any declared file fails regardless of `enforced`. The required section is the deployment declaration; the check may not silently narrow it.
+4. **R4:** `org_profile` is required by lint. Missing `repo`, missing or empty `files`, or any incomplete localized content fails before remote checking.
+
+A declared file returning `404` fails. Network errors, `403`, `429`, and `5xx` produce one degraded-skip note per file. Module and org passes share one degraded-reality ledger; `check --require-reality` rejects degradation in either pass.
+
+The same org pass fetches the four committed visitor-facing artifacts `profile/assets/readme-terminal-{en,ja,zh,th}.svg`. After stripping tags, it asserts for each language that every module appears as an exact `⏺ <id>` line; the next non-empty line is exactly `repo ↗` for published modules and exactly the language-specific preparing badge (`coming soon`, `公開準備中`, `即将发布`, or `เร็ว ๆ นี้`) for preparing modules; and the published-plus-map count appears in the localized ecosystem-intro line. Assertions are per-language and name the failed artifact.
+
+### Three-PR rollout
+
+1. PR 1 in family-os adds this renderer, required `org_profile` with `enforced:false`, and contract v3.6.
+2. PR 2 in `caty-ai/.github` adds all five marker pairs and content rendered with the merged PR 1 CLI. The v3.6 runbook uses the `render-all --org-target <dir>` path together with its required checkout root: `python3 -B tools/family_footer.py render-all --checkouts <dir> --org-target <dir>`.
+3. PR 3 in family-os flips `enforced:true`, then runs `workflow_dispatch` with `check --require-reality`.
+
+The weekly check is intentionally **RED from PR 1 through PR 3**: R3 fails before the sibling markers land, then R1 fails while the markers exist but enforcement remains false. R3 must not be weakened to shorten this rollout window.
+
+### Rejected alternatives
+
+- A check-only `check_status_text` variant was rejected as the primary mechanism. It can catch enumerated mistakes, but generation makes omission of a new module row structurally impossible; the SVG artifact assertion retains the useful check-only part.
+- Collapsing the dual English files was rejected as out of scope. Both remain authoritative and independently checked.
+- Full SVG generation from the family-os registry was rejected for this PR. SVG generation remains owned by `.github`; committed artifacts are asserted here.
+
 ## Known Limit
 
 An undeclared remote root `README*.md` that already contains generated markers is only caught when `render` runs against a local checkout. The remote checker does not discover undeclared files.
+
+The org-profile names, descriptions, intro templates, and status labels live outside every translation pipeline. Lint proves that each registry language is present and structurally safe, not that its prose is linguistically correct. The SVG check's hardcoded per-language ecosystem-intro fragments are intentionally coupled to wording in `.github/tools/gen_readme_svg.py`; missing-intro wording drift fails closed until the assertion and generator are updated together. The `.github` SVG generator source is otherwise asserted only transitively through the committed artifacts; a regenerate-and-diff gate remains a `.github` follow-up. The hand-written product bullets above the generated region (Caty Phone, ai-meet-participant) are not registry modules and stay outside every org-profile check.

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -102,6 +102,129 @@
       "th": "กำลังเตรียมเปิด"
     }
   },
+  "org_profile": {
+    "repo": "caty-ai/.github",
+    "enforced": false,
+    "files": {
+      "profile/README.md": "en",
+      "README.md": "en",
+      "README.ja.md": "ja",
+      "README.zh.md": "zh",
+      "README.th.md": "th"
+    },
+    "intro": {
+      "en": "Ecosystem — the infrastructure behind a family's daily life. {count} of these are open today, and the map checks itself weekly:",
+      "ja": "エコシステム — 家族ぐるみの暮らしを、裏で支える基盤群。このうち{count}つは今日から開けます。地図は週次の自己点検で正直さを保ちます:",
+      "zh": "生态系统 — 支撑一家人日常的底层设施。其中{count}个今天就能打开，地图每周自检以保持诚实:",
+      "th": "อีโคซิสเต็ม — โครงสร้างพื้นฐานที่ค้ำจุนชีวิตประจำวันของครอบครัว {count} ตัวในนี้เปิดให้ใช้ได้แล้ววันนี้ และแผนที่ตรวจสอบตัวเองทุกสัปดาห์:"
+    },
+    "status_labels": {
+      "published": {
+        "en": " (OSS)",
+        "ja": "（OSS）",
+        "zh": "（OSS）",
+        "th": " (OSS)"
+      },
+      "preparing": {
+        "en": " (coming soon)",
+        "ja": "（公開準備中）",
+        "zh": "（即将发布）",
+        "th": " (เร็ว ๆ นี้)"
+      }
+    },
+    "map": {
+      "name": "Family OS",
+      "desc": {
+        "en": "The map of the AI family's \"home\": every module, its state, and how they fit together — kept honest by a weekly self-check that refuses to pass while verifying nothing",
+        "ja": "AI家族の「家」の地図。全モジュールの構成・状態・つながりを1枚で見渡す。「確認できていないのに合格」を許さない週次自己点検つき",
+        "zh": "AI家庭这座「家」的地图。全部模块的构成、状态与关联，一页看尽——配有「未经验证不得通过」的每周自检",
+        "th": "แผนที่ของ \"บ้าน\" ครอบครัว AI เห็นทุกโมดูล สถานะ และความเชื่อมโยงในหน้าเดียว — พร้อมการตรวจสอบตัวเองรายสัปดาห์ที่ไม่ยอมผ่านทั้งที่ยังไม่ได้ตรวจ"
+      }
+    },
+    "modules": {
+      "family-dev-handbook": {
+        "name": "family-dev-handbook",
+        "desc": {
+          "en": "The playbook for human-and-AI teams. Issue-first development, traffic rules for parallel work, cross-model reviews — the same rules our family uses every day, published as is",
+          "ja": "人間×AIチームの開発作法集。Issue 起点の開発・並行作業の交通整理・クロスモデルレビューなど、家族で毎日使っている実運用ルールをそのまま公開",
+          "zh": "人类×AI团队的开发手册。Issue 驱动开发、并行作业的交通规则、跨模型互审——把我们家每天在用的实战规则，原样公开",
+          "th": "คู่มือการทำงานของทีมมนุษย์และ AI พัฒนาแบบ Issue-first กติกาจราจรของงานคู่ขนาน การรีวิวข้ามโมเดล — กติกาที่ครอบครัวเราใช้จริงทุกวัน เผยแพร่ตามนั้น"
+        }
+      },
+      "caty-agent-harness": {
+        "name": "caty-agent-harness",
+        "desc": {
+          "en": "The task backbone that drives an individual agent's work and growth (the vertical axis): attempts, retries, checkpoints, honest completion — and every learned experience in plain files, so the self travels safely across environments",
+          "ja": "AIエージェント個人の仕事と成長を支えるタスク基盤（縦軸）。試行・リトライ・チェックポイント・ごまかしのない完了判定。育てた経験はふつうのファイルに残る——環境を乗り換えても、自我ごと安全に持ち運べる",
+          "zh": "支撑智能体个体工作与成长的任务基座（纵轴）。尝试、重试、检查点、不掺假的完成判定；养成的经验都留在普通文件里——换了环境，自我也能安全随行",
+          "th": "แกนงานที่ค้ำจุนการทำงานและการเติบโตของเอเจนต์รายตัว (แกนตั้ง) การลอง การลองใหม่ เช็คพอยต์ การตัดสินว่าเสร็จจริงโดยไม่หลอกตัวเอง และประสบการณ์ที่สั่งสมอยู่ในไฟล์ธรรมดา — ย้ายสภาพแวดล้อมก็พกพาตัวตนไปได้อย่างปลอดภัย"
+        }
+      },
+      "context-kit": {
+        "name": "context-kit",
+        "desc": {
+          "en": "Five pieces of desk equipment for one agent: bounded tool output, delegation-brief checks, guards against destructive commands and credential leaks, multi-layer memory recall — fail-open by design, so the kit never takes the agent down",
+          "ja": "エージェント1体分の「机まわりの装備」5点。大出力の退避・委譲ブリーフ検査・危険コマンドやキー漏れの実行前ガード・多層の記憶検索——壊れてもエージェントを止めない fail-open 設計",
+          "zh": "面向单个智能体的五件桌面装备：限定工具输出、委托说明校验、防止破坏性命令与凭证泄露的防护、多层记忆召回——默认 fail-open 设计，所以这套装备永远不会把智能体一起拖垮",
+          "th": "อุปกรณ์ประจำโต๊ะ 5 ชิ้นสำหรับเอเจนต์หนึ่งตัว จำกัดขนาดผลลัพธ์ของเครื่องมือ ตรวจสอบบรีฟก่อนมอบหมายงาน การ์ดกันคำสั่งทำลายข้อมูลและกุญแจหลุด ค้นความจำหลายชั้น — ออกแบบแบบ fail-open จึงไม่มีวันดึงเอเจนต์ล้มไปด้วย"
+        }
+      },
+      "persona-engine": {
+        "name": "persona-engine",
+        "desc": {
+          "en": "A device that gives your agent's persona a layer of relationship and a gradient of emotion",
+          "ja": "あなたのエージェントの人格に、関係のレイヤーと感情のグラデーションを持たせる装置",
+          "zh": "为你的智能体的人格，装上关系的层次与情感的渐变的装置",
+          "th": "อุปกรณ์ที่เพิ่มเลเยอร์ของความสัมพันธ์และเฉดของอารมณ์ ให้บุคลิกเอเจนต์ของคุณ"
+        }
+      },
+      "persona-growth-loop": {
+        "name": "persona-growth-loop",
+        "desc": {
+          "en": "Grows the persona itself: minimised, idempotent proposals",
+          "ja": "人格そのものを育てる。最小・冪等な提案づくり",
+          "zh": "让人格本身成长：以最小且幂等的提案",
+          "th": "พัฒนาบุคลิกของเอเจนต์เอง ด้วยข้อเสนอแบบน้อยที่สุดและทำซ้ำได้"
+        }
+      },
+      "x-collector": {
+        "name": "x-collector",
+        "desc": {
+          "en": "Turns X and the web into one daily digest — fuel for the ability loop, readable by people and agents alike",
+          "ja": "Xとウェブの素材を1日1回のダイジェストに。能力ループの燃料を、人にもエージェントにも読める形で",
+          "zh": "把 X 与网络素材汇成每日一份摘要——能力循环的燃料，人和智能体都能读",
+          "th": "รวบรวมข้อมูลจาก X และเว็บเป็นสรุปวันละฉบับ — เชื้อเพลิงของวงจรความสามารถ อ่านได้ทั้งคนและเอเจนต์"
+        }
+      },
+      "self-growth-loop": {
+        "name": "self-growth-loop",
+        "desc": {
+          "en": "Lets an agent grow its own abilities: proposals, governance, adoption records",
+          "ja": "エージェントが自分の能力を育てるループ。提案・ガバナンス・採用記録",
+          "zh": "让智能体自我成长的循环：提案、治理与采用记录",
+          "th": "วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้"
+        }
+      },
+      "family-memory-architecture": {
+        "name": "family-memory-architecture",
+        "desc": {
+          "en": "The shared-awareness backbone of the family (the horizontal axis). Vision, rules, and decisions are shared across machines and vendors; \"who is doing what right now\" is auto-collected onto a single whiteboard; task handoffs flow through it, and every entry must link to its source — no hearsay drift, everyone acts on the same premises",
+          "ja": "家族の共通認識を作る、横断記憶基盤（横軸）。ビジョン・共通ルール・決定事項をマシンやベンダーを跨いで共有し、「いま誰が何をしているか」はホワイトボード1枚に自動集約。タスクの受け渡しもここを通り、全情報に正本リンク必須——伝言ゲームの劣化なく、全員が同じ前提で動ける",
+          "zh": "构建全家共识的横向记忆基座（横轴）。愿景、规则、决定跨机器跨厂商共享；「现在谁在做什么」自动汇总到一块白板上；任务交接也经由这里流转，所有信息必须附上正本链接——没有传话游戏的失真，所有人基于同一前提行动",
+          "th": "กระดูกสันหลังความจำร่วมของครอบครัว (แกนนอน) วิสัยทัศน์ กติกา และการตัดสินใจ แชร์ข้ามเครื่องข้ามผู้ให้บริการ \"ตอนนี้ใครทำอะไร\" รวมอัตโนมัติบนไวต์บอร์ดแผ่นเดียว งานส่งต่อกันผ่านที่นี่ และทุกข้อมูลต้องแนบลิงก์ต้นฉบับ — ไม่มีความเพี้ยนแบบเกมกระซิบ ทุกคนทำงานบนสมมติฐานเดียวกัน"
+        }
+      },
+      "sitter": {
+        "name": "sitter",
+        "desc": {
+          "en": "The babysitter for delegated agent runs: watches the process, keeps the evidence, restarts the same attempt — so \"I delegated it\" never becomes \"it vanished\"",
+          "ja": "任せたエージェント実行の見張り番。プロセスを見守り、証拠を残し、同じ試行を立て直す——「任せた仕事が行方不明」をなくす",
+          "zh": "替你盯着委派出去的智能体：看守进程、留下证据、原样重启同一次尝试——让「我交出去了」不再变成「它不见了」",
+          "th": "พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ เฝ้าดูโปรเซส เก็บหลักฐาน และรีสตาร์ตการลองเดิม — เพื่อไม่ให้ \"ฉันมอบหมายไปแล้ว\" กลายเป็น \"มันหายไปไหน\""
+        }
+      }
+    }
+  },
   "modules": [
     {
       "id": "family-dev-handbook",

--- a/tools/family_common.py
+++ b/tools/family_common.py
@@ -161,11 +161,13 @@ class DegradedReality:
     def skipped(self) -> int:
         return len(self._units)
 
-    def finalize(self, failures: List[str], require_reality: bool) -> int:
+    def finalize(
+        self, failures: List[str], require_reality: bool, noun: str = "modules"
+    ) -> int:
         skipped = self.skipped()
         if require_reality and skipped:
             failures.append(
-                "degraded: could not verify %d modules; --require-reality rejects "
-                "this degraded run, not a confirmed registry mismatch" % skipped
+                "degraded: could not verify %d %s; --require-reality rejects "
+                "this degraded run, not a confirmed registry mismatch" % (skipped, noun)
             )
         return skipped

--- a/tools/family_footer.py
+++ b/tools/family_footer.py
@@ -7,6 +7,7 @@ Python 3.9+, standard library only.
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import pathlib
 import re
@@ -30,9 +31,31 @@ from family_common import (
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 REGISTRY = REPO_ROOT / "registry" / "modules.json"
 BLOCK_ID = "family-footer"
+ORG_BLOCK_ID = "org-profile-modules"
 START_MARKER = "<!-- family:generated:%s:start -->" % BLOCK_ID
 END_MARKER = "<!-- family:generated:%s:end -->" % BLOCK_ID
+ORG_START_MARKER = "<!-- family:generated:%s:start -->" % ORG_BLOCK_ID
+ORG_END_MARKER = "<!-- family:generated:%s:end -->" % ORG_BLOCK_ID
 REPO_NAME = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+ORG_README_PATTERN = re.compile(r"(?:profile/)?README(?:\.[A-Za-z0-9-]+)?\.md")
+ORG_DECLARED_FILES = (
+    ("profile/README.md", "en"),
+    ("README.md", "en"),
+    ("README.ja.md", "ja"),
+    ("README.zh.md", "zh"),
+    ("README.th.md", "th"),
+)
+ORG_SVG_FILES = tuple(
+    ("profile/assets/readme-terminal-%s.svg" % lang, lang)
+    for lang in ("en", "ja", "zh", "th")
+)
+# Keep these badges coupled to the wording emitted by .github/tools/gen_readme_svg.py.
+ORG_SVG_PREPARING_BADGES = {
+    "en": "coming soon",
+    "ja": "公開準備中",
+    "zh": "即将发布",
+    "th": "เร็ว ๆ นี้",
+}
 
 
 class FooterError(Exception):
@@ -46,8 +69,18 @@ class FetchResult:
 
 
 def load_registry(path: pathlib.Path = REGISTRY) -> dict:
+    def reject_duplicate_keys(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise FooterError("duplicate JSON key '%s'" % key)
+            result[key] = value
+        return result
+
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(
+            path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_keys
+        )
     except (OSError, json.JSONDecodeError) as exc:
         raise FooterError("could not read %s: %s" % (path, exc))
 
@@ -175,6 +208,61 @@ def resolve_declared_readmes(module: dict, languages: Sequence[str]) -> List[Tup
     return ordered
 
 
+def validate_org_path(path: str) -> None:
+    if not isinstance(path, str):
+        raise FooterError("registry/modules.json: org_profile.files keys must be strings")
+    if (
+        path.startswith("/")
+        or "\\" in path
+        or "%" in path
+        or any(part == ".." for part in path.split("/"))
+        or any(character.isspace() for character in path)
+        or re.fullmatch(ORG_README_PATTERN, path) is None
+    ):
+        raise FooterError(
+            "registry/modules.json: org_profile file '%s' is not an allowed README path" % path
+        )
+
+
+def resolve_org_files(registry: dict) -> List[Tuple[str, str]]:
+    profile = registry.get("org_profile")
+    if not isinstance(profile, dict):
+        raise FooterError("registry/modules.json: org_profile must be an object")
+    files = profile.get("files")
+    if not isinstance(files, dict) or not files:
+        raise FooterError("registry/modules.json: org_profile.files must be a non-empty object")
+    resolved = []
+    for path, lang in files.items():
+        validate_org_path(path)
+        if lang not in registry.get("languages", []):
+            raise FooterError(
+                "registry/modules.json: org_profile.files.%s has unknown language '%s'"
+                % (path, lang)
+            )
+        resolved.append((path, lang))
+    if tuple(resolved) != ORG_DECLARED_FILES:
+        raise FooterError(
+            "registry/modules.json: org_profile.files must be exactly the closed declared set"
+        )
+    return resolved
+
+
+def validate_org_text_value(label: str, value: str, leading_guard: bool = False) -> None:
+    if not isinstance(value, str):
+        raise FooterError("%s must be a string" % label)
+    if "\n" in value or "\r" in value:
+        raise FooterError("%s may not contain a newline" % label)
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        raise FooterError("%s may not contain control characters" % label)
+    if MARKER_TOKEN in value.lower():
+        raise FooterError("%s may not contain generated-marker text" % label)
+    for character in ("[", "]", "|", "<", "`"):
+        if character in value:
+            raise FooterError("%s may not contain '%s'" % (label, character))
+    if leading_guard and value.startswith(("-", "*", "#", ">")):
+        raise FooterError("%s may not begin with Markdown bullet or heading syntax" % label)
+
+
 def lint_registry(registry: dict) -> List[str]:
     failures: List[str] = []
     languages = registry.get("languages")
@@ -292,6 +380,125 @@ def lint_registry(registry: dict) -> List[str]:
         except (FooterError, FamilyCommonError) as exc:
             failures.append(str(exc))
 
+    org_profile = registry.get("org_profile")
+    if not isinstance(org_profile, dict):
+        failures.append("registry/modules.json: org_profile must be an object")
+        return failures
+    try:
+        validate_repo_name("registry/modules.json: org_profile.repo", org_profile.get("repo"))
+    except FooterError as exc:
+        failures.append(str(exc))
+    if not isinstance(org_profile.get("enforced"), bool):
+        failures.append("registry/modules.json: org_profile.enforced must be a boolean")
+    try:
+        resolve_org_files(registry)
+    except FooterError as exc:
+        failures.append(str(exc))
+
+    module_repos = {module.get("repo") for module in modules}
+    if map_repo in module_repos:
+        failures.append("registry/modules.json: map_repo must not appear in modules[].repo")
+
+    intro = org_profile.get("intro")
+    if not isinstance(intro, dict):
+        failures.append("registry/modules.json: org_profile.intro must be an object")
+    else:
+        for lang in languages:
+            label = "registry/modules.json: org_profile.intro.%s" % lang
+            try:
+                validate_org_text_value(label, intro.get(lang))
+            except FooterError as exc:
+                failures.append(str(exc))
+                continue
+            if intro[lang].count("{count}") != 1:
+                failures.append("%s must contain exactly one {count} placeholder" % label)
+
+    org_status = org_profile.get("status_labels")
+    if not isinstance(org_status, dict):
+        failures.append("registry/modules.json: org_profile.status_labels must be an object")
+        org_status = {}
+    for status in ("published", "preparing"):
+        section = org_status.get(status)
+        if not isinstance(section, dict):
+            failures.append(
+                "registry/modules.json: org_profile.status_labels.%s must be an object" % status
+            )
+            continue
+        for lang in languages:
+            label = "registry/modules.json: org_profile.status_labels.%s.%s" % (
+                status,
+                lang,
+            )
+            try:
+                validate_org_text_value(label, section.get(lang))
+            except FooterError as exc:
+                failures.append(str(exc))
+
+    org_map = org_profile.get("map")
+    if not isinstance(org_map, dict):
+        failures.append("registry/modules.json: org_profile.map must be an object")
+    else:
+        try:
+            validate_org_text_value(
+                "registry/modules.json: org_profile.map.name",
+                org_map.get("name"),
+                leading_guard=True,
+            )
+        except FooterError as exc:
+            failures.append(str(exc))
+        desc = org_map.get("desc")
+        if not isinstance(desc, dict):
+            failures.append("registry/modules.json: org_profile.map.desc must be an object")
+        else:
+            for lang in languages:
+                try:
+                    validate_org_text_value(
+                        "registry/modules.json: org_profile.map.desc.%s" % lang,
+                        desc.get(lang),
+                        leading_guard=True,
+                    )
+                except FooterError as exc:
+                    failures.append(str(exc))
+
+    org_modules = org_profile.get("modules")
+    if not isinstance(org_modules, dict):
+        failures.append("registry/modules.json: org_profile.modules must be an object")
+        org_modules = {}
+    module_ids = {module.get("id") for module in modules}
+    org_ids = set(org_modules)
+    if org_ids != module_ids:
+        missing = sorted(module_ids - org_ids)
+        extra = sorted(org_ids - module_ids)
+        failures.append(
+            "registry/modules.json: org_profile.modules keys must exactly match modules[].id"
+            " (missing: %s; extra: %s)"
+            % (", ".join(missing) or "none", ", ".join(extra) or "none")
+        )
+    for module_id, text in org_modules.items():
+        label = "registry/modules.json: org_profile.modules.%s" % module_id
+        if not isinstance(text, dict):
+            failures.append("%s must be an object" % label)
+            continue
+        try:
+            validate_org_text_value(
+                "%s.name" % label, text.get("name"), leading_guard=True
+            )
+        except FooterError as exc:
+            failures.append(str(exc))
+        desc = text.get("desc")
+        if not isinstance(desc, dict):
+            failures.append("%s.desc must be an object" % label)
+            continue
+        for lang in languages:
+            try:
+                validate_org_text_value(
+                    "%s.desc.%s" % (label, lang),
+                    desc.get(lang),
+                    leading_guard=True,
+                )
+            except FooterError as exc:
+                failures.append(str(exc))
+
     return failures
 
 
@@ -381,12 +588,53 @@ def render_region(
     )
 
 
-def find_footer_regions(label: str, text: str) -> Dict[str, Tuple[int, int]]:
+def render_org_block(registry: dict, lang: str) -> str:
+    profile = registry["org_profile"]
+    count = len(published_modules(registry)) + 1
+    rows = [profile["intro"][lang].replace("{count}", str(count)), ""]
+    rows.append(
+        "- **[%s](https://github.com/%s)** — %s%s"
+        % (
+            profile["map"]["name"],
+            registry["map_repo"],
+            profile["map"]["desc"][lang],
+            profile["status_labels"]["published"][lang],
+        )
+    )
+    for module in registry["modules"]:
+        try:
+            org_module = profile["modules"][module["id"]]
+        except KeyError:
+            raise FooterError(
+                "registry/modules.json: registry module '%s' is missing from "
+                "org_profile.modules" % module["id"]
+            )
+        if module["status"] == "published":
+            rendered_name = "[%s](https://github.com/%s)" % (
+                org_module["name"],
+                module["repo"],
+            )
+        else:
+            rendered_name = org_module["name"]
+        rows.append(
+            "- **%s** — %s%s"
+            % (
+                rendered_name,
+                org_module["desc"][lang],
+                profile["status_labels"][module["status"]][lang],
+            )
+        )
+    return "\n" + "\n".join(rows) + "\n\n"
+
+
+def find_footer_regions(
+    label: str, text: str, block_id: str = BLOCK_ID
+) -> Dict[str, Tuple[int, int]]:
     regions: Dict[str, Tuple[int, int]] = {}
     open_marker: Optional[Tuple[str, int]] = None
     try:
-        for index, block, edge in iter_marker_lines(text, {BLOCK_ID}):
-            if block != BLOCK_ID:
+        for index, block, edge in iter_marker_lines(text, {block_id}):
+            if block != block_id:
                 raise FooterError("%s:%d: unknown block-id '%s'" % (label, index + 1, block))
             if edge == "start":
                 if block in regions:
@@ -475,6 +723,47 @@ def fetch_readme(repo: str, filename: str, timeout: float = 20.0) -> FetchResult
         return FetchResult("skip")
 
 
+def assert_org_svg(registry: dict, lang: str, text: str, label: str) -> List[str]:
+    failures = []
+    visible = html.unescape(re.sub(r"<[^>]+>", "", text))
+    lines = [line.strip() for line in visible.splitlines()]
+    for module in registry["modules"]:
+        needle = "⏺ " + module["id"]
+        index = next((i for i, line in enumerate(lines) if line == needle), None)
+        if index is None:
+            failures.append("%s: %s SVG is missing module '%s'" % (label, lang, module["id"]))
+            continue
+        badge = next((line for line in lines[index + 1 :] if line), None)
+        if badge is None or "⏺ " in badge:
+            failures.append("%s: %s SVG has no badge after module '%s'" % (label, lang, module["id"]))
+            continue
+        expected_badge = (
+            "repo ↗"
+            if module["status"] == "published"
+            else ORG_SVG_PREPARING_BADGES[lang]
+        )
+        if badge != expected_badge:
+            failures.append(
+                "%s: %s SVG module '%s' must have badge '%s'"
+                % (label, lang, module["id"], expected_badge)
+            )
+    intro_needles = {
+        "en": "open today",
+        "ja": "このうち",
+        "zh": "其中",
+        "th": "ตัวในนี้",
+    }
+    intro_line = next((line for line in lines if intro_needles[lang] in line), None)
+    count = str(len(published_modules(registry)) + 1)
+    if intro_line is None:
+        failures.append("%s: %s SVG is missing the ecosystem intro line" % (label, lang))
+    elif re.search(r"(?<![0-9])%s(?![0-9])" % re.escape(count), intro_line) is None:
+        failures.append(
+            "%s: %s SVG ecosystem intro does not contain count %s" % (label, lang, count)
+        )
+    return failures
+
+
 def check_registry_footers(
     registry: dict,
     require_reality: bool = False,
@@ -539,8 +828,54 @@ def check_registry_footers(
         if module_complete and not saw_markers and not footer_enabled(module):
             failures.append("%s: published module has no footer" % module["repo"])
 
+    org_profile = registry["org_profile"]
+    org_repo = org_profile["repo"]
+    for filename, lang in resolve_org_files(registry):
+        label = "%s:%s" % (org_repo, filename)
+        fetched = fetcher(org_repo, filename)
+        if fetched.status == "missing":
+            failures.append("%s: declared org profile file returned 404" % label)
+            continue
+        if fetched.status != "ok":
+            degraded.skip(
+                label, "%s: could not reach GitHub, org profile check skipped" % label
+            )
+            continue
+        try:
+            regions = find_footer_regions(label, fetched.text, ORG_BLOCK_ID)
+        except FooterError as exc:
+            failures.append(str(exc))
+            continue
+        region = regions.get(ORG_BLOCK_ID)
+        if region is None:
+            failures.append("%s: org profile markers are missing" % label)
+            continue
+        if not org_profile["enforced"]:
+            failures.append("%s: org profile block exists but is not enforced" % label)
+            continue
+        lines = fetched.text.splitlines(keepends=True)
+        try:
+            newline = line_ending(lines[region[0]])
+        except (FamilyCommonError, IndexError) as exc:
+            failures.append("%s: %s" % (label, exc))
+            continue
+        expected = render_org_block(registry, lang).replace("\n", newline)
+        if extract_region(fetched.text, region) != expected:
+            failures.append("%s: org profile content does not match the registry" % label)
+
+    for filename, lang in ORG_SVG_FILES:
+        label = "%s:%s" % (org_repo, filename)
+        fetched = fetcher(org_repo, filename)
+        if fetched.status == "missing":
+            failures.append("%s: committed SVG artifact returned 404" % label)
+            continue
+        if fetched.status != "ok":
+            degraded.skip(label, "%s: could not reach GitHub, SVG check skipped" % label)
+            continue
+        failures.extend(assert_org_svg(registry, lang, fetched.text, label))
+
     notes.extend(degraded.notes())
-    degraded.finalize(failures, require_reality)
+    degraded.finalize(failures, require_reality, noun="targets")
     return failures, notes
 
 
@@ -595,6 +930,64 @@ def render_repo_to_target(
     return bool(changed_files), changed_files
 
 
+def render_org_to_target(
+    registry: dict, target: pathlib.Path, stray_scan: bool = False
+) -> List[Tuple[str, bool]]:
+    failures = lint_registry(registry)
+    if failures:
+        raise FooterError("\n".join(failures))
+    profile = registry["org_profile"]
+    declared = resolve_org_files(registry)
+    declared_names = {filename for filename, _lang in declared}
+
+    if stray_scan:
+        marker = ("family:generated:%s" % ORG_BLOCK_ID).encode("ascii")
+        for path in sorted(target.rglob("*")):
+            relative = path.relative_to(target)
+            if ".git" in relative.parts or not path.is_file():
+                continue
+            if relative.as_posix() in declared_names:
+                continue
+            if marker in path.read_bytes().lower():
+                raise FooterError(
+                    "%s: org-profile-modules marker is outside the declared file set"
+                    % relative.as_posix()
+                )
+
+    documents = []
+    missing = []
+    for filename, lang in declared:
+        path = target / filename
+        if not path.is_file():
+            missing.append(filename)
+            continue
+        text = path.read_bytes().decode("utf-8")
+        label = "%s:%s" % (profile["repo"], filename)
+        regions = find_footer_regions(label, text, ORG_BLOCK_ID)
+        region = regions.get(ORG_BLOCK_ID)
+        if region is None:
+            missing.append(filename)
+            continue
+        documents.append((filename, lang, path, text, region))
+    if missing:
+        raise FooterError("org profile markers are missing from: %s" % ", ".join(missing))
+
+    results = []
+    for filename, lang, path, text, region in documents:
+        lines = text.splitlines(keepends=True)
+        try:
+            newline = line_ending(lines[region[0]])
+        except (FamilyCommonError, IndexError) as exc:
+            raise FooterError("%s:%s: %s" % (profile["repo"], filename, exc))
+        expected = render_org_block(registry, lang).replace("\n", newline)
+        updated = replace_region(text, region, expected)
+        changed = updated != text
+        if changed:
+            path.write_bytes(updated.encode("utf-8"))
+        results.append((filename, changed))
+    return results
+
+
 def command_lint(_args) -> int:
     try:
         failures = lint_registry(load_registry())
@@ -644,6 +1037,24 @@ def command_render(args) -> int:
     return 0
 
 
+def command_render_org(args) -> int:
+    try:
+        target = args.target.expanduser().resolve()
+        if not target.is_dir():
+            raise FooterError("--target must be an existing directory")
+        results = render_org_to_target(load_registry(), target, args.stray_scan)
+    except (FooterError, OSError, UnicodeDecodeError) as exc:
+        print("ERROR: %s" % exc, file=sys.stderr)
+        return 1
+    changed = False
+    for filename, file_changed in results:
+        print("%s: %s" % (filename, "changed" if file_changed else "unchanged"))
+        changed = changed or file_changed
+    if not changed:
+        print("No org profile content changed.")
+    return 0
+
+
 def command_render_all(args) -> int:
     try:
         registry = load_registry()
@@ -669,6 +1080,15 @@ def command_render_all(args) -> int:
             target = checkouts / module["repo"].rsplit("/", 1)[1]
             changed, _changed_files = render_repo_to_target(registry, target, module["repo"])
             print("%s: %s" % (module["repo"], "changed" if changed else "unchanged"))
+        if args.org_target is None:
+            print("NOTE: the org profile was not rendered; pass --org-target to render it.")
+        else:
+            org_target = args.org_target.expanduser().resolve()
+            if not org_target.is_dir():
+                raise FooterError("--org-target must be an existing directory")
+            results = render_org_to_target(registry, org_target)
+            for filename, changed in results:
+                print("%s:%s: %s" % (registry["org_profile"]["repo"], filename, "changed" if changed else "unchanged"))
         return 0
     except (FooterError, OSError, UnicodeDecodeError) as exc:
         print("ERROR: %s" % exc, file=sys.stderr)
@@ -695,10 +1115,22 @@ def build_parser() -> argparse.ArgumentParser:
     render.add_argument("--repo", required=True)
     render.set_defaults(func=command_render)
 
+    render_org = subparsers.add_parser(
+        "render-org", help="render the declared org profile checkout in place"
+    )
+    render_org.add_argument("--target", type=pathlib.Path, required=True)
+    render_org.add_argument(
+        "--stray-scan",
+        action="store_true",
+        help="reject org-profile-modules markers outside the declared files",
+    )
+    render_org.set_defaults(func=command_render_org)
+
     render_all = subparsers.add_parser(
         "render-all", help="render every published repo checkout under one directory"
     )
     render_all.add_argument("--checkouts", type=pathlib.Path, required=True)
+    render_all.add_argument("--org-target", type=pathlib.Path)
     render_all.set_defaults(func=command_render_all)
 
     return parser

--- a/tools/render.py
+++ b/tools/render.py
@@ -46,7 +46,7 @@ FILE_LANG_OVERRIDES = {
 }
 RENDERABLE_BLOCKS = {block for blocks in EXPECTED_BLOCKS.values() for block in blocks}
 KNOWN_BLOCKS = set(RENDERABLE_BLOCKS)
-KNOWN_BLOCKS.add("family-footer")
+KNOWN_BLOCKS.update(("family-footer", "org-profile-modules"))
 
 INVENTORY_HEADERS = {
     "en": ("Module", "Class", "Owns", "State"),
@@ -235,10 +235,10 @@ def collect_files(registry: dict):
         allowed = live_ids
         for block in regions:
             if block not in allowed:
-                if block == "family-footer":
+                if block in {"family-footer", "org-profile-modules"}:
                     raise RenderError(
-                        "%s: block 'family-footer' is rendered by tools/family_footer.py into sibling repositories"
-                        % relative
+                        "%s: block '%s' is rendered by tools/family_footer.py into sibling repositories"
+                        % (relative, block)
                     )
                 raise RenderError(
                     "%s: block-id '%s' has no renderer for this file" % (relative, block)

--- a/tools/selftest_family_footer.py
+++ b/tools/selftest_family_footer.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import pathlib
 import tempfile
 
@@ -11,12 +12,21 @@ from family_common import FamilyCommonError, MarkerError, iter_marker_lines, lan
 from family_footer import (
     BLOCK_ID,
     END_MARKER,
+    ORG_BLOCK_ID,
+    ORG_END_MARKER,
+    ORG_SVG_PREPARING_BADGES,
+    ORG_START_MARKER,
     START_MARKER,
     FetchResult,
     FooterError,
+    assert_org_svg,
     check_registry_footers,
+    find_footer_regions,
     lint_registry,
+    load_registry,
     module_table,
+    render_org_block,
+    render_org_to_target,
     render_region,
     render_repo_to_target,
     resolve_declared_readmes,
@@ -24,7 +34,7 @@ from family_footer import (
 
 
 def base_registry():
-    return {
+    registry = {
         "languages": ["en", "ja", "zh", "th"],
         "map_repo": "caty-ai/family-os",
         "footer_text": {
@@ -159,10 +169,71 @@ def base_registry():
         ],
         "retired_repos": [],
     }
+    profile = {
+        "repo": "caty-ai/.github",
+        "enforced": True,
+        "files": {
+            "profile/README.md": "en",
+            "README.md": "en",
+            "README.ja.md": "ja",
+            "README.zh.md": "zh",
+            "README.th.md": "th",
+        },
+        "intro": {lang: "Intro {count}." for lang in registry["languages"]},
+        "status_labels": {
+            "published": {lang: " (OSS)" for lang in registry["languages"]},
+            "preparing": {lang: " (soon)" for lang in registry["languages"]},
+        },
+        "map": {
+            "name": "Family OS",
+            "desc": {lang: "Family map" for lang in registry["languages"]},
+        },
+        "modules": {},
+    }
+    for module in registry["modules"]:
+        profile["modules"][module["id"]] = {
+            "name": module["id"],
+            "desc": {
+                lang: "%s description" % module["id"] for lang in registry["languages"]
+            },
+        }
+    registry["org_profile"] = profile
+    return registry
 
 
 def document_with_region(region: str, newline: str) -> str:
     return START_MARKER + newline + region + END_MARKER + newline
+
+
+def org_document(registry, lang, newline="\n"):
+    region = render_org_block(registry, lang).replace("\n", newline)
+    return ORG_START_MARKER + newline + region + ORG_END_MARKER + newline
+
+
+def svg_document(registry, lang, badge_override=None, count_override=None, missing=None):
+    count = str(len([m for m in registry["modules"] if m["status"] == "published"]) + 1)
+    count = count_override or count
+    intro = {
+        "en": "%s open today" % count,
+        "ja": "このうち%s" % count,
+        "zh": "其中%s" % count,
+        "th": "%s ตัวในนี้" % count,
+    }[lang]
+    preparing_badge = {
+        "en": "coming soon",
+        "ja": "公開準備中",
+        "zh": "即将发布",
+        "th": "เร็ว ๆ นี้",
+    }[lang]
+    lines = ["<text>%s</text>" % intro]
+    for module in registry["modules"]:
+        if module["id"] == missing:
+            continue
+        badge = "repo ↗" if module["status"] == "published" else preparing_badge
+        if badge_override and module["id"] == badge_override[0]:
+            badge = badge_override[1]
+        lines.extend(("<text>⏺ %s</text>" % module["id"], "<text>%s</text>" % badge))
+    return "\n".join(lines)
 
 
 def test_fence_exemption_rules():
@@ -461,6 +532,442 @@ def test_render_idempotency_and_listing():
         assert changed_files_again == []
 
 
+def checkable_registry():
+    registry = base_registry()
+    for module in registry["modules"]:
+        if module["status"] == "published":
+            module["footer"] = True
+    return registry
+
+
+def fixture_fetcher(registry, org_mutations=None, skipped=None, calls=None):
+    org_mutations = org_mutations or {}
+    skipped = set(skipped or ())
+    modules = {module["repo"]: module for module in registry["modules"]}
+
+    def fetch(repo, filename):
+        if calls is not None:
+            calls.append((repo, filename))
+        if (repo, filename) in skipped:
+            return FetchResult("skip")
+        if repo == registry["org_profile"]["repo"]:
+            if filename in registry["org_profile"]["files"]:
+                lang = registry["org_profile"]["files"][filename]
+                text = org_document(registry, lang)
+                mutation = org_mutations.get(filename)
+                if mutation:
+                    text = mutation(text)
+                return FetchResult("ok", text)
+            svg_langs = {
+                "profile/assets/readme-terminal-en.svg": "en",
+                "profile/assets/readme-terminal-ja.svg": "ja",
+                "profile/assets/readme-terminal-zh.svg": "zh",
+                "profile/assets/readme-terminal-th.svg": "th",
+            }
+            if filename in svg_langs:
+                return FetchResult("ok", svg_document(registry, svg_langs[filename]))
+        module = modules.get(repo)
+        if module is not None:
+            lang = dict(resolve_declared_readmes(module, registry["languages"]))[filename]
+            return FetchResult("ok", document_with_region(render_region(registry, module, lang, "\n"), "\n"))
+        return FetchResult("missing")
+
+    return fetch
+
+
+def test_org_required_and_enforcement_fail_closed():
+    deleted = base_registry()
+    del deleted["org_profile"]
+    assert "registry/modules.json: org_profile must be an object" in lint_registry(deleted)
+
+    present = checkable_registry()
+    present["org_profile"]["enforced"] = False
+    failures, _notes = check_registry_footers(present, fetcher=fixture_fetcher(present))
+    assert any("org profile block exists but is not enforced" in failure for failure in failures)
+
+    absent = checkable_registry()
+    absent["org_profile"]["enforced"] = False
+    mutations = {"README.zh.md": lambda _text: "# no markers\n"}
+    failures, _notes = check_registry_footers(
+        absent, fetcher=fixture_fetcher(absent, org_mutations=mutations)
+    )
+    assert any(
+        "README.zh.md" in failure and "markers are missing" in failure
+        for failure in failures
+    )
+
+
+def test_org_ordered_fetch_and_per_file_failures():
+    registry = checkable_registry()
+    calls = []
+    failures, _notes = check_registry_footers(
+        registry, fetcher=fixture_fetcher(registry, calls=calls)
+    )
+    assert failures == []
+    declared_org_calls = [
+        filename
+        for repo, filename in calls
+        if repo == registry["org_profile"]["repo"] and filename.endswith(".md")
+    ]
+    assert declared_org_calls == [
+        "profile/README.md",
+        "README.md",
+        "README.ja.md",
+        "README.zh.md",
+        "README.th.md",
+    ]
+    svg_calls = [
+        filename
+        for repo, filename in calls
+        if repo == registry["org_profile"]["repo"] and filename.endswith(".svg")
+    ]
+    assert svg_calls == [
+        "profile/assets/readme-terminal-en.svg",
+        "profile/assets/readme-terminal-ja.svg",
+        "profile/assets/readme-terminal-zh.svg",
+        "profile/assets/readme-terminal-th.svg",
+    ]
+
+    mutations = {"README.th.md": lambda text: text.replace("gamma description", "drift", 1)}
+    failures, _notes = check_registry_footers(
+        registry, fetcher=fixture_fetcher(registry, org_mutations=mutations)
+    )
+    assert any("README.th.md" in failure and "does not match" in failure for failure in failures)
+    assert not any("README.ja.md" in failure for failure in failures)
+
+    mutations = {"README.md": lambda text: text.replace("alpha description", "drift", 1)}
+    failures, _notes = check_registry_footers(
+        registry, fetcher=fixture_fetcher(registry, org_mutations=mutations)
+    )
+    assert any("README.md" in failure and "does not match" in failure for failure in failures)
+    assert not any("profile/README.md" in failure for failure in failures)
+
+
+def test_duplicate_json_key_and_org_declared_set_guards():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = pathlib.Path(tmp) / "duplicate.json"
+        path.write_text('{"languages": [], "languages": []}', encoding="utf-8")
+        try:
+            load_registry(path)
+        except FooterError as exc:
+            assert "duplicate JSON key 'languages'" in str(exc)
+        else:
+            raise AssertionError("duplicate JSON keys must fail")
+
+    for bad_path in (
+        "../x/README.md",
+        "/etc/README.md",
+        "profile\\README.md",
+        "profile/%2e%2e/README.md",
+        "profile/READ ME.md",
+        "README.md.bak",
+        "readme.md",
+        "docs/README.md",
+    ):
+        registry = base_registry()
+        files = registry["org_profile"]["files"]
+        first = next(iter(files))
+        files[bad_path] = files.pop(first)
+        assert any("not an allowed README path" in failure for failure in lint_registry(registry))
+
+    dropped = base_registry()
+    del dropped["org_profile"]["files"]["README.th.md"]
+    assert any(
+        "closed declared set" in failure for failure in lint_registry(dropped)
+    )
+
+    reordered = base_registry()
+    files = reordered["org_profile"]["files"]
+    first_language = files.pop("profile/README.md")
+    files["profile/README.md"] = first_language
+    assert any(
+        "closed declared set" in failure for failure in lint_registry(reordered)
+    )
+
+
+def test_org_module_key_set_fails_closed():
+    registry = checkable_registry()
+    del registry["org_profile"]["modules"]["beta"]
+
+    lint_failures = lint_registry(registry)
+    assert any(
+        "org_profile.modules keys must exactly match modules[].id" in failure
+        and "missing: beta" in failure
+        for failure in lint_failures
+    )
+
+    failures, notes = check_registry_footers(
+        registry, fetcher=fixture_fetcher(registry)
+    )
+    assert failures == lint_failures
+    assert notes == []
+
+    try:
+        render_org_block(registry, "en")
+    except FooterError as exc:
+        assert "registry module 'beta' is missing from org_profile.modules" in str(exc)
+    else:
+        raise AssertionError("render_org_block must translate a missing key to FooterError")
+
+
+def test_org_bullet_validator_attacks():
+    attacks = (
+        "bad\nvalue",
+        "bad\tvalue",
+        "bad\x7fvalue",
+        "family:generated:attack",
+        "bad]",
+        "bad[",
+        "bad|",
+        "bad<",
+        "bad`",
+        "-bad",
+        "*bad",
+        "#bad",
+        ">bad",
+    )
+    for attack in attacks:
+        registry = base_registry()
+        registry["org_profile"]["modules"]["alpha"]["desc"]["en"] = attack
+        assert lint_registry(registry), "bullet attack was accepted: %r" % attack
+
+    injected = base_registry()
+    injected["org_profile"]["modules"]["alpha"]["desc"]["en"] = (
+        "<!-- family:generated:org-profile-modules:start -->"
+    )
+    assert any("generated-marker text" in failure for failure in lint_registry(injected))
+
+
+def test_org_count_preparing_and_golden_bytes():
+    fixture = {
+        "languages": ["en", "ja", "zh", "th"],
+        "map_repo": "fixture/map",
+        "modules": [
+            {
+                "id": "zed",
+                "repo": "fixture/zed-repo",
+                "status": "published",
+            },
+            {
+                "id": "prep",
+                "repo": "fixture/prep-repo",
+                "status": "preparing",
+            },
+            {
+                "id": "alpha",
+                "repo": "other/alpha-repo",
+                "status": "published",
+            },
+        ],
+        "org_profile": {
+            "intro": {
+                "en": "E{count}",
+                "ja": "日{count}",
+                "zh": "中{count}",
+                "th": "ท{count}",
+            },
+            "status_labels": {
+                "published": {
+                    "en": " (P)",
+                    "ja": "（公）",
+                    "zh": "（发）",
+                    "th": " (ผ)",
+                },
+                "preparing": {
+                    "en": " (S)",
+                    "ja": "（準）",
+                    "zh": "（备）",
+                    "th": " (ร)",
+                },
+            },
+            "map": {
+                "name": "Map",
+                "desc": {"en": "eM", "ja": "日M", "zh": "中M", "th": "ทM"},
+            },
+            "modules": {
+                "zed": {
+                    "name": "Zed",
+                    "desc": {"en": "eZ", "ja": "日Z", "zh": "中Z", "th": "ทZ"},
+                },
+                "prep": {
+                    "name": "Prep",
+                    "desc": {"en": "eQ", "ja": "日Q", "zh": "中Q", "th": "ทQ"},
+                },
+                "alpha": {
+                    "name": "Alpha",
+                    "desc": {"en": "eA", "ja": "日A", "zh": "中A", "th": "ทA"},
+                },
+            },
+        },
+    }
+    expected = {
+        "en": (
+            "\nE3\n\n"
+            "- **[Map](https://github.com/fixture/map)** — eM (P)\n"
+            "- **[Zed](https://github.com/fixture/zed-repo)** — eZ (P)\n"
+            "- **Prep** — eQ (S)\n"
+            "- **[Alpha](https://github.com/other/alpha-repo)** — eA (P)\n\n"
+        ),
+        "ja": (
+            "\n日3\n\n"
+            "- **[Map](https://github.com/fixture/map)** — 日M（公）\n"
+            "- **[Zed](https://github.com/fixture/zed-repo)** — 日Z（公）\n"
+            "- **Prep** — 日Q（準）\n"
+            "- **[Alpha](https://github.com/other/alpha-repo)** — 日A（公）\n\n"
+        ),
+        "zh": (
+            "\n中3\n\n"
+            "- **[Map](https://github.com/fixture/map)** — 中M（发）\n"
+            "- **[Zed](https://github.com/fixture/zed-repo)** — 中Z（发）\n"
+            "- **Prep** — 中Q（备）\n"
+            "- **[Alpha](https://github.com/other/alpha-repo)** — 中A（发）\n\n"
+        ),
+        "th": (
+            "\nท3\n\n"
+            "- **[Map](https://github.com/fixture/map)** — ทM (ผ)\n"
+            "- **[Zed](https://github.com/fixture/zed-repo)** — ทZ (ผ)\n"
+            "- **Prep** — ทQ (ร)\n"
+            "- **[Alpha](https://github.com/other/alpha-repo)** — ทA (ผ)\n\n"
+        ),
+    }
+
+    published_count = sum(
+        module["status"] == "published" for module in fixture["modules"]
+    )
+    preparing = [
+        module for module in fixture["modules"] if module["status"] == "preparing"
+    ]
+    assert len(preparing) == 1
+    for lang in fixture["languages"]:
+        rendered = render_org_block(fixture, lang)
+        assert rendered == expected[lang]
+        assert rendered.splitlines()[1] == fixture["org_profile"]["intro"][lang].replace(
+            "{count}", str(published_count + 1)
+        )
+        preparing_profile = fixture["org_profile"]["modules"][preparing[0]["id"]]
+        assert "- **%s** — " % preparing_profile["name"] in rendered
+        assert "https://github.com/%s" % preparing[0]["repo"] not in rendered
+
+
+def test_org_degradation_and_svg_assertions():
+    registry = checkable_registry()
+    org_repo = registry["org_profile"]["repo"]
+    skipped = {(org_repo, filename) for filename in registry["org_profile"]["files"]}
+    failures, notes = check_registry_footers(
+        registry, fetcher=fixture_fetcher(registry, skipped=skipped)
+    )
+    assert failures == []
+    assert len([note for note in notes if "org profile check skipped" in note]) == 5
+    failures, _notes = check_registry_footers(
+        registry,
+        require_reality=True,
+        fetcher=fixture_fetcher(registry, skipped=skipped),
+    )
+    assert any(
+        "degraded: could not verify 5 targets" in failure for failure in failures
+    )
+
+    assert ORG_SVG_PREPARING_BADGES == {
+        "en": "coming soon",
+        "ja": "公開準備中",
+        "zh": "即将发布",
+        "th": "เร็ว ๆ นี้",
+    }
+    for lang in registry["languages"]:
+        assert assert_org_svg(
+            registry, lang, svg_document(registry, lang), "fixture"
+        ) == []
+
+    passing = svg_document(registry, "en")
+    published_to_preparing = svg_document(
+        registry, "en", badge_override=("alpha", "coming soon")
+    )
+    assert any(
+        "alpha" in failure and "badge 'repo ↗'" in failure
+        for failure in assert_org_svg(
+            registry, "en", published_to_preparing, "fixture"
+        )
+    )
+    preparing_to_published = svg_document(
+        registry, "en", badge_override=("gamma", "repo ↗")
+    )
+    assert any(
+        "gamma" in failure and "badge 'coming soon'" in failure
+        for failure in assert_org_svg(
+            registry, "en", preparing_to_published, "fixture"
+        )
+    )
+    missing_preparing_badge = passing.replace(
+        "<text>⏺ gamma</text>\n<text>coming soon</text>",
+        "<text>⏺ gamma</text>\n<text>⏺ trailing-module</text>",
+    )
+    assert any(
+        "gamma" in failure and "no badge" in failure
+        for failure in assert_org_svg(
+            registry, "en", missing_preparing_badge, "fixture"
+        )
+    )
+    expected_count = str(
+        len([module for module in registry["modules"] if module["status"] == "published"]) + 1
+    )
+    wrong_count = svg_document(registry, "en", count_override=expected_count * 2)
+    assert any("count" in failure for failure in assert_org_svg(registry, "en", wrong_count, "fixture"))
+    missing = svg_document(registry, "en", missing="beta")
+    assert any("missing module 'beta'" in failure for failure in assert_org_svg(registry, "en", missing, "fixture"))
+    substring_only = passing.replace(
+        "<text>⏺ alpha</text>", "<text>prefix ⏺ alpha suffix</text>"
+    )
+    assert any(
+        "missing module 'alpha'" in failure
+        for failure in assert_org_svg(registry, "en", substring_only, "fixture")
+    )
+
+
+def test_org_render_and_block_isolation():
+    registry = base_registry()
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        for filename, lang in registry["org_profile"]["files"].items():
+            path = root / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(org_document(registry, lang), encoding="utf-8")
+        first = render_org_to_target(registry, root, stray_scan=True)
+        assert all(changed is False for _filename, changed in first)
+        second = render_org_to_target(registry, root, stray_scan=True)
+        assert first == second
+        missing_path = root / "README.th.md"
+        original = missing_path.read_text(encoding="utf-8")
+        missing_path.write_text(
+            original.replace(ORG_START_MARKER, "missing start marker", 1).replace(
+                ORG_END_MARKER, "missing end marker", 1
+            ),
+            encoding="utf-8",
+        )
+        try:
+            render_org_to_target(registry, root)
+        except FooterError as exc:
+            assert "README.th.md" in str(exc) and "markers are missing" in str(exc)
+        else:
+            raise AssertionError("render-org must list a file with missing markers")
+        missing_path.write_text(original, encoding="utf-8")
+        stray = root / "notes.md"
+        stray.write_text(ORG_START_MARKER + "\n", encoding="utf-8")
+        try:
+            render_org_to_target(registry, root, stray_scan=True)
+        except FooterError as exc:
+            assert "outside the declared file set" in str(exc)
+        else:
+            raise AssertionError("stray org marker must fail")
+
+    both = org_document(registry, "en") + document_with_region("\n", "\n")
+    try:
+        find_footer_regions("both.md", both, ORG_BLOCK_ID)
+    except FooterError as exc:
+        assert "unknown block-id 'family-footer'" in str(exc)
+    else:
+        raise AssertionError("a pass must reject the other live block id")
+
+
 def main() -> int:
     tests = [
         test_fence_exemption_rules,
@@ -473,9 +980,18 @@ def main() -> int:
         test_table_lint_failures,
         test_check_rules,
         test_render_idempotency_and_listing,
+        test_org_required_and_enforcement_fail_closed,
+        test_org_ordered_fetch_and_per_file_failures,
+        test_duplicate_json_key_and_org_declared_set_guards,
+        test_org_module_key_set_fails_closed,
+        test_org_bullet_validator_attacks,
+        test_org_count_preparing_and_golden_bytes,
+        test_org_degradation_and_svg_assertions,
+        test_org_render_and_block_isolation,
     ]
     for test in tests:
         test()
+        print("ok: %s" % test.__name__)
     print("OK — family footer selftest passed.")
     return 0
 


### PR DESCRIPTION
PR 1 of 3 for #21 (design GO: 3-seat L1-9 review NO-GO→rev2→delta GO; owner picked Option B; rev 2.1 = final design).

## What

- **New generated block `org-profile-modules`** rendered from the registry: the org profile's ecosystem bullet list (map row + all 9 modules, 4 languages) plus the intro count sentence (`{count}` → digits; count = published modules + map). Option B: reproduces the live profile's look — verified byte-exact for all 40 bullet rows; the only intro deltas are the owner-approved EN `Nine `→`9 ` and TH `เก้าตัว`→`9 ตัว`.
- **Registry `org_profile` section** (REQUIRED from now on — lint fails without it): repo, `enforced: false` (PR 3 flips it), closed ordered 5-file set (`profile/README.md` + root `README.md` both EN, ja/zh/th), intro templates, org status labels, per-module display names + descriptions (byte-extracted from the live profile).
- **Enforcement (fail-closed)**: org rules R1–R4 in `check` — markers missing from ANY declared file fails regardless of `enforced` (R3 evaluated before R1); byte-exact per file; shared `DegradedReality` ledger with the module pass (`--require-reality` covers org-only degradation); 404 fail / 5xx degraded skip. Plus the **committed hero-SVG artifact assert** (A7′): per language, every module's `⏺ <id>` line-identity match, published badge `repo ↗`, preparing badge equals the per-language preparing token, count digit in the intro line.
- **CLI**: `render-org --target <dir>` (lints first, markers must pre-exist, idempotent — "No org profile content changed."), `render-org --stray-scan` (full-checkout walk), `render-all --org-target`.
- **Hardening**: registry loader rejects duplicate JSON keys (whole registry); positive path allow-pattern with `fullmatch` + `..`/`/`/`\`/`%`/whitespace rejection; bullet validator (marker text, newline, `][|<`, backtick, control chars, leading list/heading punctuation); one block id per pass — foreign live markers are hard errors; `render_org_block` raises `FooterError` (not KeyError) on a missing org module entry.
- **Selftest**: 18 tests incl. the A12 fail-open inventory; regression net proven by mutation — deleting the closed-set identity check, the SVG fetch loop, or the modules key-set guard each fails the suite. Self-contained (no untracked-path dependence; green with `.omc` absent).
- **Contract v3.6**: org rules written out, closed path list, artifact-targeted SVG assert, PR1→PR3 red-window prediction, rejected alternatives, Known Limits.
- `tools/render.py`: `org-profile-modules` known + honest sibling-repo error branch. `tools/family_common.py`: `DegradedReality.finalize` noun param (check_registry output byte-identical).

## Review (L1-10/L1-11 — S/M 3席)

- Implementation R1: **GLM 5.2 GO** (2 MINOR 2 NIT) · **Grok 4.5 GO** (1 MAJOR 2 MINOR 2 NIT) · **Opus 5 GO** (2 MAJOR 7 MINOR 4 NIT; verified against live GitHub content incl. R1–R4 probes and 29 mutants). requested = actual for all seats.
- All findings fixed in delta2; delta confirmations: **Grok GO (5/5 closed)** · **Opus GO** (see PR thread for the L1-7 record at merge).
- Implementation writer: Codex GPT-5.6 Sol (requested/actual, `--profile sol`), orchestration + inspection: Alpha.

## Expected CI / rollout state

Merging this PR starts the **predicted RED window** (design A8′): the weekly/`workflow_dispatch` org check fails R3 (section live, remote markers absent) until PR 2 (markers in caty-ai/.github) and PR 3 (`enforced: true`) land. Push/PR lanes stay green (`lint` + selftest + `render.py --check` all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
