### PR TITLE
registry: enforce the org profile block (PR 3/3 for #21)

### DIFF
--- a/registry/modules.json
+++ b/registry/modules.json
@@ -104,7 +104,7 @@
   },
   "org_profile": {
     "repo": "caty-ai/.github",
-    "enforced": false,
+    "enforced": true,
     "files": {
       "profile/README.md": "en",
       "README.md": "en",


### PR DESCRIPTION
Final PR of the #21 rollout: `org_profile.enforced` false → true (1 line). Pre-flip proof from this branch: `python3 -B tools/family_footer.py check --require-reality` → **OK — family footer content matches the registry** (live remote fetch: member footers + 5 org profile files + 4 SVG artifacts). lint + selftest green. After merge: `workflow_dispatch` to turn the scheduled lane green same-day per the contract runbook.

Review: 2 seats (GLM + Grok) → local merge under noreply identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)