### PR TITLE
docs: live CI badge (family links) in header

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,6 +13,7 @@
 
 ![Family OSのブランドHero。左に「FAMILY OS」「A MAP FOR GROWING AI FAMILIES」「caty-ai/family-os」「FREE & OPEN SOURCE · MIT LICENSE」の文字、右に温かいレトロTV風の惑星系がある。中央の大きな地球はAI家族を見渡す地図の比喩であり、周囲の独立した世界と組み合わせる衛星は役割の比喩である。画像だけで接続関係は示さず、正確な関係はファミリーマップ図とその脇の表に示す。](assets/readme/hero.png)
 
+[![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![install](https://img.shields.io/badge/install-not%20required-brightgreen)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 ![Family OS brand hero. On the left, the words "FAMILY OS", "A MAP FOR GROWING AI FAMILIES", "caty-ai/family-os", and "FREE & OPEN SOURCE · MIT LICENSE"; on the right, a warm retro-TV planetary system. The large central globe is a metaphor for a map that overlooks an AI family, and the independent worlds and composable satellites around it are a metaphor for roles. The image encodes no connections on its own; the exact relationships are shown in the family map figure and the tables beside it.](assets/readme/hero.png)
 
+[![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![install](https://img.shields.io/badge/install-not%20required-brightgreen)
 

--- a/README.th.md
+++ b/README.th.md
@@ -13,6 +13,7 @@
 
 ![ภาพแบรนด์ฮีโร่ของ Family OS ด้านซ้ายมีข้อความ "FAMILY OS", "A MAP FOR GROWING AI FAMILIES", "caty-ai/family-os" และ "FREE & OPEN SOURCE · MIT LICENSE" ด้านขวาเป็นระบบดาวเคราะห์สไตล์ทีวีย้อนยุคโทนอบอุ่น โลกใบใหญ่ตรงกลางเป็นอุปมาของแผนที่ที่มองเห็นครอบครัว AI ทั้งหมด ส่วนโลกอิสระและดาวเทียมที่ประกอบเข้าด้วยกันรอบ ๆ เป็นอุปมาของบทบาท ภาพนี้ไม่ได้แสดงความสัมพันธ์ในการเชื่อมต่อด้วยตัวเอง ความสัมพันธ์ที่ถูกต้องแสดงอยู่ในภาพแผนที่ครอบครัวและตารางข้างภาพ](assets/readme/hero.png)
 
+[![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![install](https://img.shields.io/badge/install-not%20required-brightgreen)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,6 +13,7 @@
 
 ![Family OS 品牌主视觉。左侧是「FAMILY OS」「A MAP FOR GROWING AI FAMILIES」「caty-ai/family-os」「FREE & OPEN SOURCE · MIT LICENSE」等文字，右侧是暖色复古电视风格的行星系。中央的大地球是「俯瞰 AI 家族的地图」的比喻，周围各自独立的世界与可组合的卫星是「角色」的比喻。图像本身不表示连接关系，准确的关系见家族地图图示及其旁边的表格。](assets/readme/hero.png)
 
+[![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![install](https://img.shields.io/badge/install-not%20required-brightgreen)
 


### PR DESCRIPTION
Adds the live family-links workflow badge (runs on push + weekly schedule, now on both ubuntu and macOS) ahead of the License badge per the readme-standard badge order. No platform badge here on purpose: the support table states the map itself is readable on macOS/Windows/Linux, so a macOS|Linux platform badge would understate it. All four language READMEs. Tracker: caty-ai/family-dev-handbook#54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)