### PR TITLE
fix: registry truth — persona-growth-loop published + orphan/retired-reverse checks (#57)

### DIFF
--- a/.github/workflows/family-links.yml
+++ b/.github/workflows/family-links.yml
@@ -108,7 +108,6 @@ jobs:
             --no-progress
             --include-fragments
             --max-concurrency 8
-            --exclude 'github\.com/shojikumaru/persona-growth-loop'
             --exclude 'img\.shields\.io'
             './**/*.md'
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -349,7 +349,7 @@ Family OS が広がっても、次の5つは変わりません。
 | 縦軸・基盤 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | AIエージェントのタスク基盤 — 試行・リトライ・チェックポイント・完了判定 | 公開・MIT |
 | 縦軸 | [context-kit](https://github.com/caty-ai/context-kit) | エージェント1体分のコンテキスト衛生キット — 大出力の退避・委譲ブリーフ検査・安全フック・記憶検索 | 公開・MIT |
 | 縦軸 | [Persona Engine](https://github.com/caty-ai/persona-engine) | エージェントに人格を与える — 人格レイヤーと感情のグラデーション | 公開・MIT |
-| 縦軸 | **Persona Growth Loop** | 人格そのものを育てる — 最小・冪等な提案づくり | 公開準備中 |
+| 縦軸 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | 人格そのものを育てる — 最小・冪等な提案づくり | 公開・MIT |
 | 縦軸 | [X Collector](https://github.com/caty-ai/x-collector) | Xやウェブの素材を1日1回のダイジェストに — 人にもエージェントにも | 公開・MIT |
 | 縦軸 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録 | 公開・MIT |
 | 横軸・基盤 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 記憶バス — 家族が知っていることを共有する層 | 公開・MIT |

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Every module on this map, with its current state — generated from the same reg
 | Vertical · foundation | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | Task backbone for AI agents — retries, checkpoints, and honest completion | published, MIT |
 | Vertical | [context-kit](https://github.com/caty-ai/context-kit) | Five-piece context hygiene kit for one agent — bounded output, delegation briefs, safety guards, recall | published, MIT |
 | Vertical | [Persona Engine](https://github.com/caty-ai/persona-engine) | Gives an agent a persona — layered personality and graded emotion | published, MIT |
-| Vertical | **Persona Growth Loop** | Grows the persona itself — minimal, idempotent proposals | publication in preparation |
+| Vertical | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | Grows the persona itself — minimal, idempotent proposals | published, MIT |
 | Vertical | [X Collector](https://github.com/caty-ai/x-collector) | Turns X and the web into one daily digest — for people and agents | published, MIT |
 | Vertical | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | Lets an agent grow its own abilities — proposals, governance, adoption records | published, MIT |
 | Horizontal · foundation | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | The memory bus — how the family shares what it knows | published, MIT |

--- a/README.th.md
+++ b/README.th.md
@@ -349,7 +349,7 @@ flowchart TB
 | แกนตั้ง · รากฐาน | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | แกนงานของเอเจนต์ AI — การลองใหม่ เช็คพอยต์ และการตัดสินว่าเสร็จจริง | เปิดแล้ว・MIT |
 | แกนตั้ง | [context-kit](https://github.com/caty-ai/context-kit) | ชุดดูแลคอนเท็กซ์สำหรับเอเจนต์หนึ่งตัว — จำกัดเอาต์พุตขนาดใหญ่, ตรวจ brief การมอบงาน, การ์ดความปลอดภัย, ค้นความทรงจำ | เปิดแล้ว・MIT |
 | แกนตั้ง | [Persona Engine](https://github.com/caty-ai/persona-engine) | มอบบุคลิกให้เอเจนต์ — เลเยอร์บุคลิกและอารมณ์แบบไล่ระดับ | เปิดแล้ว・MIT |
-| แกนตั้ง | **Persona Growth Loop** | พัฒนาบุคลิกของเอเจนต์ — สร้างข้อเสนอแบบน้อยที่สุดและทำซ้ำได้ | กำลังเตรียมเปิด |
+| แกนตั้ง | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | พัฒนาบุคลิกของเอเจนต์ — สร้างข้อเสนอแบบน้อยที่สุดและทำซ้ำได้ | เปิดแล้ว・MIT |
 | แกนตั้ง | [X Collector](https://github.com/caty-ai/x-collector) | รวบรวมข้อมูลจาก X และเว็บเป็นสรุปวันละฉบับ — สำหรับคนและเอเจนต์ | เปิดแล้ว・MIT |
 | แกนตั้ง | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง — ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้ | เปิดแล้ว・MIT |
 | แกนนอน · รากฐาน | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้ | เปิดแล้ว・MIT |

--- a/README.zh.md
+++ b/README.zh.md
@@ -349,7 +349,7 @@ Family OS 这边没有要做的事。不用安装，不用注册账号，也没�
 | 纵轴・基座 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | AI 智能体的任务基座 — 重试、检查点与完成判定 | 已公开・MIT |
 | 纵轴 | [context-kit](https://github.com/caty-ai/context-kit) | 面向单个智能体的上下文卫生工具组 — 限制大输出、委托简报校验、安全防护、记忆检索 | 已公开・MIT |
 | 纵轴 | [Persona Engine](https://github.com/caty-ai/persona-engine) | 为智能体赋予人格 — 分层人格与情感渐变 | 已公开・MIT |
-| 纵轴 | **Persona Growth Loop** | 让人格本身成长 — 以最小且幂等的提案 | 准备公开中 |
+| 纵轴 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | 让人格本身成长 — 以最小且幂等的提案 | 已公开・MIT |
 | 纵轴 | [X Collector](https://github.com/caty-ai/x-collector) | 把 X 与网络素材汇成每日一份摘要 — 给人也给智能体 | 已公开・MIT |
 | 纵轴 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | 让智能体自我成长的循环 — 提案、治理与采用记录 | 已公开・MIT |
 | 横轴・基座 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 记忆总线 — 家族共享所知的一层 | 已公开・MIT |

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -62,7 +62,7 @@ flowchart TB
 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | runtime・縦軸の基盤 | タスクの意味・試行・リトライ・チェックポイント・完了判定・完了・DLQ | 公開・MIT |
 | [context-kit](https://github.com/caty-ai/context-kit) | runtime・机まわりの装備 | ツール出力の退避と抜粋・委譲ブリーフ検査・危険削除/公開事故/キー漏れのガード・1体分の記憶検索 | 公開・MIT |
 | [Persona Engine](https://github.com/caty-ai/persona-engine) | runtime・単独利用可能 | 人格のレイヤーと感情のグラデーション | 公開・MIT |
-| [Persona Growth Loop](https://github.com/shojikumaru/persona-growth-loop) | 計画中のフロントエンド | 最小化された冪等な提案の生成 | 公開準備中・計画中 |
+| [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | runtime・アプリケーション | 最小化された冪等な提案の生成 | 公開・MIT |
 | [X Collector](https://github.com/caty-ai/x-collector) | runtime・任意の入力 | 能力ループ向けの外部素材の収集 | 公開・MIT |
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime・アプリケーション | 提案・ガバナンス・採用記録・成長の解釈 | 公開・MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime・横方向の基盤 | 記憶バス・登録されたスケジュールの期待・check-in・来歴 | 公開・MIT |

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -62,7 +62,7 @@ The rules layer sits **above** both axes rather than inside either one. It is a 
 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | runtime, vertical foundation | task meaning, attempt, retry, checkpoint, done-check, completion, dead-letter | published, MIT |
 | [context-kit](https://github.com/caty-ai/context-kit) | runtime, desk equipment | bounded tool output and scratch persistence, delegation-brief validation, destructive/public-repo/credential guards, one agent's memory recall | published, MIT |
 | [Persona Engine](https://github.com/caty-ai/persona-engine) | runtime, standalone | persona layers and emotion gradation | published, MIT |
-| [Persona Growth Loop](https://github.com/shojikumaru/persona-growth-loop) | planned frontend | minimised, idempotent proposal production | publication in preparation; planned |
+| [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | runtime, application | minimised, idempotent proposal production | published, MIT |
 | [X Collector](https://github.com/caty-ai/x-collector) | runtime, optional input | collecting external material for the ability loop | published, MIT |
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime, application | proposal, governance, adoption records, growth interpretation | published, MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | published, MIT |

--- a/docs/readme-visual-system.md
+++ b/docs/readme-visual-system.md
@@ -141,7 +141,7 @@ the generated block directly.
 | Caty Agent Harness | `caty-ai/caty-agent-harness` | published, MIT |
 | context-kit | `caty-ai/context-kit` | published, MIT |
 | Persona Engine | `caty-ai/persona-engine` | published, MIT |
-| Persona Growth Loop | `shojikumaru/persona-growth-loop` | publication in preparation; planned |
+| Persona Growth Loop | `caty-ai/persona-growth-loop` | published, MIT |
 | X Collector | `caty-ai/x-collector` | published, MIT |
 | Self Growth Loop | `caty-ai/self-growth-loop` | published, MIT |
 | Family Memory Architecture | `caty-ai/family-memory-architecture` | published, MIT |

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -336,8 +336,8 @@
     {
       "id": "persona-growth-loop",
       "name": "Persona Growth Loop",
-      "repo": "shojikumaru/persona-growth-loop",
-      "status": "preparing",
+      "repo": "caty-ai/persona-growth-loop",
+      "status": "published",
       "tagline": {
         "en": "Grows the persona itself — minimal, idempotent proposals",
         "ja": "人格そのものを育てる — 最小・冪等な提案づくり",
@@ -348,18 +348,14 @@
         "group": "vertical",
         "foundation": false
       },
-      "license": null,
+      "license": "MIT",
       "class": {
-        "en": "planned frontend",
-        "ja": "計画中のフロントエンド"
+        "en": "runtime, application",
+        "ja": "runtime・アプリケーション"
       },
       "owns": {
         "en": "minimised, idempotent proposal production",
         "ja": "最小化された冪等な提案の生成"
-      },
-      "note": {
-        "en": "planned",
-        "ja": "計画中"
       }
     },
     {
@@ -486,6 +482,11 @@
     {
       "repo": "shojikumaru/self-growth-loop",
       "superseded_by": "caty-ai/self-growth-loop",
+      "reason": "republished under caty-ai as a fresh repository, so GitHub does not redirect"
+    },
+    {
+      "repo": "shojikumaru/persona-growth-loop",
+      "superseded_by": "caty-ai/persona-growth-loop",
       "reason": "republished under caty-ai as a fresh repository, so GitHub does not redirect"
     }
   ]

--- a/tools/check_registry.py
+++ b/tools/check_registry.py
@@ -22,6 +22,7 @@ Python 3.9+, standard library only.
 """
 
 import argparse
+import http.client
 import json
 import pathlib
 import re
@@ -217,9 +218,9 @@ def fetch_org_repos(org: str, timeout: float = 20.0):
     org to stay under one page forever.
 
     Returns the list of full names on success, or None if GitHub could not
-    be reached, returned a non-200 status, or the response could not be
-    parsed (including anonymous rate-limiting) — the caller treats None as a
-    non-fatal degraded skip, never a confirmed empty org.
+    be reached, returned a non-200 status, or the response could not be read
+    or parsed (including anonymous rate-limiting) — the caller treats None as
+    a non-fatal degraded skip, never a confirmed empty org.
     """
     names = []
     url = "https://api.github.com/orgs/%s/repos?per_page=100&type=public" % org
@@ -238,7 +239,7 @@ def fetch_org_repos(org: str, timeout: float = 20.0):
                     return None
                 payload = json.loads(response.read().decode("utf-8"))
                 link_header = response.headers.get("Link")
-        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError):
+        except (OSError, http.client.HTTPException, json.JSONDecodeError, UnicodeDecodeError):
             return None
         if not isinstance(payload, list):
             return None
@@ -260,11 +261,14 @@ def check_orphan(
         return 0
     org = map_repo.split("/", 1)[0]
 
-    accounted = {module["repo"] for module in registry["modules"]}
-    accounted.add(map_repo)
+    accounted = {module["repo"].casefold() for module in registry["modules"]}
+    accounted.add(map_repo.casefold())
     org_profile_repo = registry.get("org_profile", {}).get("repo")
     if org_profile_repo:
-        accounted.add(org_profile_repo)
+        accounted.add(org_profile_repo.casefold())
+    accounted.update(
+        entry["repo"].casefold() for entry in registry.get("retired_repos", [])
+    )
 
     org_repos = fetch_org_repos(org)
     if org_repos is None:
@@ -274,7 +278,7 @@ def check_orphan(
         )
     else:
         for repo in org_repos:
-            if repo not in accounted:
+            if repo.casefold() not in accounted:
                 failures.append(
                     "orphan: %s is a public repository in %s but is not listed "
                     "in registry/modules.json. Add it to modules[] (or "
@@ -296,20 +300,20 @@ def check_retired(registry: dict, root: pathlib.Path, failures: list) -> None:
         except (OSError, UnicodeDecodeError):
             continue
         for repo, entry in retired.items():
-            needle = "github.com/%s" % repo
-            pattern = re.compile(re.escape(needle) + r"(?![A-Za-z0-9_-])")
-            for match in pattern.finditer(text):
-                line = text[: match.start()].count("\n") + 1
-                failures.append(
-                    "retired: %s:%d links to %s, which has moved to %s (%s)"
-                    % (
-                        path.relative_to(root),
-                        line,
-                        repo,
-                        entry["superseded_by"],
-                        entry["reason"],
+            for needle in ("github.com/%s" % repo, "github\\.com/%s" % repo):
+                pattern = re.compile(re.escape(needle) + r"(?![A-Za-z0-9_-])")
+                for match in pattern.finditer(text):
+                    line = text[: match.start()].count("\n") + 1
+                    failures.append(
+                        "retired: %s:%d links to %s, which has moved to %s (%s)"
+                        % (
+                            path.relative_to(root),
+                            line,
+                            repo,
+                            entry["superseded_by"],
+                            entry["reason"],
+                        )
                     )
-                )
 
 
 def check_status_text(registry: dict, root: pathlib.Path, failures: list) -> int:

--- a/tools/check_registry.py
+++ b/tools/check_registry.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
 """Check that what the documentation says about each module is still true.
 
-Three checks, in order of how badly each one bites:
+Four checks, in order of how badly each one bites:
 
 1. reality      — every module's declared status matches what GitHub actually
                   serves to an anonymous visitor. Catches the case where a repo
                   is published (or unpublished) and the map has not noticed.
-2. retired      — no document links to a repository we have moved away from.
-                  Publishing under a fresh repository forfeits GitHub's
-                  automatic redirect, so an old URL is a hard 404.
-3. status-text  — wherever a module link appears, the status wording next to it
+2. orphan       — every public repository in the org is accounted for by the
+                  registry. Catches the case where a repo was created (or
+                  un-retired) on GitHub and nobody added it to the map.
+3. retired      — no tracked text file links to a repository we have moved
+                  away from. Publishing under a fresh repository forfeits
+                  GitHub's automatic redirect, so an old URL is a hard 404.
+4. status-text  — wherever a module link appears, the status wording next to it
                   matches the registry, in that file's language. Catches the
                   reverse of (1): a live link with a stale label beside it.
 
-Run with --offline to skip the network check.
+Run with --offline to skip the network checks (reality and orphan).
 
 Python 3.9+, standard library only.
 """
@@ -37,6 +40,17 @@ LANG_SUFFIX = re.compile(r"\.(?P<lang>[a-z]{2}(?:-[A-Z]{2})?)\.md$")
 # Never attribute status wording beyond the link's own local claim.
 MAX_STATUS_SPAN = 200
 
+# Every tracked text suffix the retired-repo check scans, not just Markdown —
+# a stray reference can hide in a workflow file just as easily as in a doc.
+RETIRED_SCAN_SUFFIXES = (".md", ".yml", ".yaml", ".py", ".json", ".toml", ".txt", ".sh")
+
+# The registry legitimately names retired repos inside retired_repos[]; that
+# is the one file the retired-reverse-reference check must never flag.
+RETIRED_SCAN_EXEMPT = pathlib.Path("registry/modules.json")
+
+# GitHub's Link header, e.g. '<https://...&page=2>; rel="next", <...>; rel="last"'.
+LINK_NEXT = re.compile(r'<(?P<url>[^>]+)>\s*;\s*rel="next"')
+
 
 def language_of(path: pathlib.Path) -> str:
     match = LANG_SUFFIX.search(path.name)
@@ -46,6 +60,26 @@ def language_of(path: pathlib.Path) -> str:
 def markdown_files(root: pathlib.Path):
     for path in sorted(root.rglob("*.md")):
         if ".git" in path.parts:
+            continue
+        yield path
+
+
+def retired_scan_files(root: pathlib.Path):
+    """Every tracked text file the retired-reverse-reference check scans.
+
+    Broader than markdown_files: a retired link can hide in a workflow file
+    (the family-links.yml:111 class of bug) just as easily as in a doc.
+    registry/modules.json is excluded — it legitimately names retired repos
+    inside retired_repos[].
+    """
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if ".git" in path.parts:
+            continue
+        if path.suffix not in RETIRED_SCAN_SUFFIXES:
+            continue
+        if path.relative_to(root) == RETIRED_SCAN_EXEMPT:
             continue
         yield path
 
@@ -174,12 +208,93 @@ def check_reality(
     return degraded.finalize(failures, require_reality)
 
 
+def fetch_org_repos(org: str, timeout: float = 20.0):
+    """Fetch every public repository's full name ("org/name") in an org.
+
+    Anonymous on purpose, same rationale as github_is_public: a token would
+    see private repositories too and could leak them into this list. Follows
+    the Link: rel="next" header to walk every page rather than trusting the
+    org to stay under one page forever.
+
+    Returns the list of full names on success, or None if GitHub could not
+    be reached, returned a non-200 status, or the response could not be
+    parsed (including anonymous rate-limiting) — the caller treats None as a
+    non-fatal degraded skip, never a confirmed empty org.
+    """
+    names = []
+    url = "https://api.github.com/orgs/%s/repos?per_page=100&type=public" % org
+    opener = urllib.request.build_opener()
+    while url:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "family-os-registry-check",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                if response.status != 200:
+                    return None
+                payload = json.loads(response.read().decode("utf-8"))
+                link_header = response.headers.get("Link")
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(payload, list):
+            return None
+        for entry in payload:
+            full_name = entry.get("full_name")
+            if full_name:
+                names.append(full_name)
+        match = LINK_NEXT.search(link_header) if link_header else None
+        url = match.group("url") if match else None
+    return names
+
+
+def check_orphan(
+    registry: dict, failures: list, notes: list, require_reality: bool = False
+) -> int:
+    degraded = DegradedReality()
+    map_repo = registry.get("map_repo")
+    if not map_repo or "/" not in map_repo:
+        return 0
+    org = map_repo.split("/", 1)[0]
+
+    accounted = {module["repo"] for module in registry["modules"]}
+    accounted.add(map_repo)
+    org_profile_repo = registry.get("org_profile", {}).get("repo")
+    if org_profile_repo:
+        accounted.add(org_profile_repo)
+
+    org_repos = fetch_org_repos(org)
+    if org_repos is None:
+        degraded.skip(
+            "org:%s" % org,
+            "org:%s: could not reach GitHub, orphan check skipped" % org,
+        )
+    else:
+        for repo in org_repos:
+            if repo not in accounted:
+                failures.append(
+                    "orphan: %s is a public repository in %s but is not listed "
+                    "in registry/modules.json. Add it to modules[] (or "
+                    "retired_repos[] if it should stay retired)."
+                    % (repo, org)
+                )
+
+    notes.extend(degraded.notes())
+    return degraded.finalize(failures, require_reality, noun="organizations")
+
+
 def check_retired(registry: dict, root: pathlib.Path, failures: list) -> None:
     retired = {entry["repo"]: entry for entry in registry.get("retired_repos", [])}
     if not retired:
         return
-    for path in markdown_files(root):
-        text = path.read_text(encoding="utf-8")
+    for path in retired_scan_files(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
         for repo, entry in retired.items():
             needle = "github.com/%s" % repo
             pattern = re.compile(re.escape(needle) + r"(?![A-Za-z0-9_-])")
@@ -242,12 +357,12 @@ def main() -> int:
     parser.add_argument(
         "--offline",
         action="store_true",
-        help="skip the GitHub reality check",
+        help="skip the GitHub reality and orphan checks",
     )
     parser.add_argument(
         "--require-reality",
         action="store_true",
-        help="fail if any module cannot be checked against GitHub",
+        help="fail if any module or the orphan check cannot be verified against GitHub",
     )
     parser.add_argument(
         "--root",
@@ -271,8 +386,10 @@ def main() -> int:
     notes: list = []
 
     skipped = 0
+    orphan_skipped = 0
     if not args.offline:
         skipped = check_reality(registry, failures, notes, args.require_reality)
+        orphan_skipped = check_orphan(registry, failures, notes, args.require_reality)
     check_retired(registry, root, failures)
     occurrences = check_status_text(registry, root, failures)
 
@@ -283,6 +400,9 @@ def main() -> int:
     if not args.offline:
         reality_targets = len(registry["modules"]) + (1 if registry.get("map_repo") else 0)
         print("reality skipped    : %d of %d" % (skipped, reality_targets))
+    print("orphan check        : %s" % ("skipped" if args.offline else "on (anonymous)"))
+    if not args.offline:
+        print("orphan skipped      : %d of 1" % orphan_skipped)
 
     for note in notes:
         print("  note: %s" % note)

--- a/tools/selftest_check_registry.py
+++ b/tools/selftest_check_registry.py
@@ -3,24 +3,38 @@
 
 from __future__ import annotations
 
+import http.client
 import pathlib
 import tempfile
 import urllib.error
 from typing import Optional
 from unittest import mock
 
-from check_registry import check_orphan, check_reality, check_retired, github_is_public
+from check_registry import (
+    check_orphan,
+    check_reality,
+    check_retired,
+    fetch_org_repos,
+    github_is_public,
+)
 
 
 class Response:
-    def __init__(self, status: int) -> None:
+    def __init__(self, status: int, read_result=b"[]") -> None:
         self.status = status
+        self.read_result = read_result
+        self.headers = {}
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         return None
+
+    def read(self):
+        if isinstance(self.read_result, BaseException):
+            raise self.read_result
+        return self.read_result
 
 
 class Opener:
@@ -71,6 +85,20 @@ def check_status_contract() -> None:
         ):
             actual = github_is_public("caty-ai/example")
         assert actual == expected, (result, expected, actual)
+
+
+def check_fetch_org_repos_read_faults_degrade() -> None:
+    faults = [
+        http.client.IncompleteRead(b""),
+        ConnectionResetError("connection reset during response read"),
+    ]
+    for fault in faults:
+        with mock.patch(
+            "check_registry.urllib.request.build_opener",
+            return_value=Opener(Response(200, fault)),
+        ):
+            actual = fetch_org_repos("caty-ai")
+        assert actual is None, (fault, actual)
 
 
 def check_unexpected_statuses_are_recorded_and_later_modules_continue() -> None:
@@ -168,6 +196,25 @@ def check_orphan_all_repos_accounted_for() -> None:
     assert failures == [], failures
 
 
+def check_orphan_accounts_for_retired_repos_case_insensitively() -> None:
+    registry = _orphan_registry()
+    registry["retired_repos"] = [{"repo": "caty-ai/retired-example"}]
+    org_repos = [
+        "Caty-AI/Family-OS",
+        "Caty-AI/Alpha",
+        "Caty-AI/Beta",
+        "Caty-AI/.GitHub",
+        "Caty-AI/Retired-Example",
+    ]
+    failures = []
+    notes = []
+    with mock.patch("check_registry.fetch_org_repos", return_value=org_repos):
+        skipped = check_orphan(registry, failures, notes)
+
+    assert skipped == 0, skipped
+    assert failures == [], failures
+
+
 def check_orphan_flags_unaccounted_public_repo() -> None:
     registry = _orphan_registry()
     org_repos = [
@@ -175,7 +222,7 @@ def check_orphan_flags_unaccounted_public_repo() -> None:
         "caty-ai/alpha",
         "caty-ai/beta",
         "caty-ai/.github",
-        "caty-ai/mystery-repo",
+        "Caty-AI/Mystery-Repo",
     ]
     failures = []
     notes = []
@@ -184,7 +231,7 @@ def check_orphan_flags_unaccounted_public_repo() -> None:
 
     assert skipped == 0, skipped
     assert len(failures) == 1, failures
-    assert failures[0].startswith("orphan: caty-ai/mystery-repo"), failures
+    assert failures[0].startswith("orphan: Caty-AI/Mystery-Repo"), failures
 
 
 def check_orphan_fetch_failure_degrades_instead_of_failing() -> None:
@@ -263,14 +310,46 @@ def check_retired_scans_beyond_markdown_but_exempts_the_registry() -> None:
     assert not any("modules.json" in failure for failure in failures), failures
 
 
+def check_retired_reports_regex_escaped_github_spelling() -> None:
+    retired_owner = "example-org"
+    retired_name = "retired-" + "escaped-example"
+    retired_repo = "%s/%s" % (retired_owner, retired_name)
+    registry = {
+        "retired_repos": [
+            {
+                "repo": retired_repo,
+                "superseded_by": "example-org/current-escaped-example",
+                "reason": "synthetic self-test fixture",
+            }
+        ]
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        yml_path = root / "family-links.yml"
+        yml_path.write_text(
+            "args: >-\n"
+            "  --exclude 'github\\.com/%s'\n" % retired_repo,
+            encoding="utf-8",
+        )
+
+        failures: list = []
+        check_retired(registry, root, failures)
+
+    assert len(failures) == 1, failures
+    assert failures[0].startswith("retired: family-links.yml:2 "), failures
+
+
 if __name__ == "__main__":
     check_status_contract()
+    check_fetch_org_repos_read_faults_degrade()
     check_unexpected_statuses_are_recorded_and_later_modules_continue()
     check_gone_statuses_hard_fail_published_modules()
     check_require_reality_escalates_unexpected_status()
     check_orphan_all_repos_accounted_for()
+    check_orphan_accounts_for_retired_repos_case_insensitively()
     check_orphan_flags_unaccounted_public_repo()
     check_orphan_fetch_failure_degrades_instead_of_failing()
     check_orphan_require_reality_escalates_fetch_failure()
     check_retired_scans_beyond_markdown_but_exempts_the_registry()
+    check_retired_reports_regex_escaped_github_spelling()
     print("selftest_check_registry: ok")

--- a/tools/selftest_check_registry.py
+++ b/tools/selftest_check_registry.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Offline self-tests for the registry reality check."""
+"""Offline self-tests for the registry reality, orphan, and retired checks."""
 
 from __future__ import annotations
 
+import pathlib
+import tempfile
 import urllib.error
 from typing import Optional
 from unittest import mock
 
-from check_registry import check_reality, github_is_public
+from check_registry import check_orphan, check_reality, check_retired, github_is_public
 
 
 class Response:
@@ -135,9 +137,140 @@ def check_require_reality_escalates_unexpected_status() -> None:
     assert any("unexpected HTTP status 401" in note for note in notes), notes
 
 
+def _orphan_registry() -> dict:
+    return {
+        "map_repo": "caty-ai/family-os",
+        "modules": [
+            {"repo": "caty-ai/alpha"},
+            {"repo": "caty-ai/beta"},
+        ],
+        "org_profile": {"repo": "caty-ai/.github"},
+    }
+
+
+def check_orphan_all_repos_accounted_for() -> None:
+    registry = _orphan_registry()
+    org_repos = [
+        "caty-ai/family-os",
+        "caty-ai/alpha",
+        "caty-ai/beta",
+        "caty-ai/.github",
+    ]
+    failures = []
+    notes = []
+    with mock.patch(
+        "check_registry.fetch_org_repos", return_value=org_repos
+    ) as probe:
+        skipped = check_orphan(registry, failures, notes)
+
+    assert probe.call_args == mock.call("caty-ai"), probe.call_args
+    assert skipped == 0, skipped
+    assert failures == [], failures
+
+
+def check_orphan_flags_unaccounted_public_repo() -> None:
+    registry = _orphan_registry()
+    org_repos = [
+        "caty-ai/family-os",
+        "caty-ai/alpha",
+        "caty-ai/beta",
+        "caty-ai/.github",
+        "caty-ai/mystery-repo",
+    ]
+    failures = []
+    notes = []
+    with mock.patch("check_registry.fetch_org_repos", return_value=org_repos):
+        skipped = check_orphan(registry, failures, notes)
+
+    assert skipped == 0, skipped
+    assert len(failures) == 1, failures
+    assert failures[0].startswith("orphan: caty-ai/mystery-repo"), failures
+
+
+def check_orphan_fetch_failure_degrades_instead_of_failing() -> None:
+    registry = _orphan_registry()
+    failures = []
+    notes = []
+    with mock.patch("check_registry.fetch_org_repos", return_value=None):
+        skipped = check_orphan(registry, failures, notes)
+
+    assert skipped == 1, skipped
+    assert failures == [], failures
+    assert any(note.startswith("org:caty-ai:") for note in notes), notes
+
+
+def check_orphan_require_reality_escalates_fetch_failure() -> None:
+    registry = _orphan_registry()
+    failures = []
+    notes = []
+    with mock.patch("check_registry.fetch_org_repos", return_value=None):
+        skipped = check_orphan(registry, failures, notes, require_reality=True)
+
+    assert skipped == 1, skipped
+    assert len(failures) == 1, failures
+    assert "--require-reality rejects this degraded run" in failures[0], failures
+
+
+def check_retired_scans_beyond_markdown_but_exempts_the_registry() -> None:
+    """Regression proof for the family-links.yml:111 blind spot: red before
+    this fix (retired scan limited to *.md), green after.
+
+    Uses a synthetic retired repo name (not a real registry entry) so this
+    fixture's own on-disk source text never collides with the retired-scan
+    regex it is exercising."""
+    retired_owner = "example-org"
+    retired_name = "retired-" + "example-repo"
+    retired_repo = "%s/%s" % (retired_owner, retired_name)
+    registry = {
+        "retired_repos": [
+            {
+                "repo": retired_repo,
+                "superseded_by": "example-org/current-example-repo",
+                "reason": "republished under example-org as a fresh repository, "
+                "so GitHub does not redirect",
+            }
+        ]
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        (root / ".github" / "workflows").mkdir(parents=True)
+        (root / "docs").mkdir()
+        (root / "registry").mkdir()
+
+        yml_path = root / ".github" / "workflows" / "family-links.yml"
+        yml_path.write_text(
+            "args: >-\n"
+            "  --exclude 'https://github.com/%s'\n" % retired_repo,
+            encoding="utf-8",
+        )
+        md_path = root / "docs" / "note.md"
+        md_path.write_text(
+            "See https://github.com/%s for history.\n" % retired_repo,
+            encoding="utf-8",
+        )
+        registry_path = root / "registry" / "modules.json"
+        registry_path.write_text(
+            '{"retired_repos": [{"repo": "%s"}]}\n' % retired_repo,
+            encoding="utf-8",
+        )
+
+        failures: list = []
+        check_retired(registry, root, failures)
+
+    assert len(failures) == 2, failures
+    assert any("family-links.yml" in failure for failure in failures), failures
+    assert any("note.md" in failure for failure in failures), failures
+    assert not any("modules.json" in failure for failure in failures), failures
+
+
 if __name__ == "__main__":
     check_status_contract()
     check_unexpected_statuses_are_recorded_and_later_modules_continue()
     check_gone_statuses_hard_fail_published_modules()
     check_require_reality_escalates_unexpected_status()
+    check_orphan_all_repos_accounted_for()
+    check_orphan_flags_unaccounted_public_repo()
+    check_orphan_fetch_failure_degrades_instead_of_failing()
+    check_orphan_require_reality_escalates_fetch_failure()
+    check_retired_scans_beyond_markdown_but_exempts_the_registry()
     print("selftest_check_registry: ok")


### PR DESCRIPTION
Closes #57 (campaign tracking: #56, W0-1).

## What
- `registry/modules.json`: persona-growth-loop → `caty-ai/persona-growth-loop` / `published` / MIT; old path appended to `retired_repos`
- `tools/check_registry.py`: **orphan check** (org public repo list vs registry, anonymous, paginated, degraded-skip on network failure, `--offline` skips, `--require-reality` escalates) + **retired-reverse scan** widened beyond Markdown to `.yml .yaml .py .json .toml .txt .sh` (`registry/modules.json` exempt) — the exact blind spot that let `family-links.yml:111` keep a lychee exclude for a retired path
- `.github/workflows/family-links.yml`: removed that lychee exclude line
- `docs/engineering.md` / `docs/engineering.ja.md` / `docs/readme-visual-system.md` + README×4 family tables: regenerated by `tools/render.py` (registry-derived; excluding them fails `render.py --check`)
- `tools/selftest_check_registry.py`: 5 new offline tests (orphan ×4, retired-reverse ×1 incl. registry-exemption proof)

## File manifest (L0-6)
`.github/workflows/family-links.yml` / `README.md` / `README.ja.md` / `README.zh.md` / `README.th.md` / `docs/engineering.md` / `docs/engineering.ja.md` / `docs/readme-visual-system.md` / `registry/modules.json` / `tools/check_registry.py` / `tools/selftest_check_registry.py` — 11 files, +282/−29, single commit 4eabc8b

Note: README×4 exceed the original WIP file prediction — they are render.py-generated family-table rows driven by the same registry change; leaving them out breaks the `render --check` CI step. Footer rollout (`footer: true`) is intentionally NOT done here — that is #58.

## Verification (local)
- `selftest_check_registry.py` → ok / `check_registry.py` online → exit 0, reality skipped 0 of 10, orphan skipped 0 of 1 / `--offline` → exit 0 / `render.py --check` → OK / `selftest_family_footer.py` → OK

Writer: Sonnet executor (requested=codex-sol, actual=sonnet — Codex usage limit until 2026-08-20 10:44, see mc-log). Review: 3 seats (GLM 5.3 / Kimi K3 / Grok 4.6) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)