### PR TITLE
ci: required claim-id floor for docs/evidence.md (#41)

### DIFF
--- a/.github/workflows/family-links.yml
+++ b/.github/workflows/family-links.yml
@@ -125,6 +125,11 @@ jobs:
           import os
           import re
 
+          # Contract A-5 (Epic #24): these claim-ids must always exist in
+          # docs/evidence.md. Changing this set requires owner approval —
+          # do not edit it in an implementation lane.
+          REQUIRED_CLAIM_IDS = ("EV-001", "EV-002", "EV-003", "EV-004")
+
           required_fields = {
               "claim-id",
               "believe",
@@ -212,6 +217,21 @@ jobs:
           )
           if duplicate_claim_ids:
               fail("duplicate claim-ids: " + ", ".join(duplicate_claim_ids))
+
+          if not REQUIRED_CLAIM_IDS:
+              fail("required set is empty — the floor has been removed")
+
+          missing_required_claim_ids = [
+              claim_id
+              for claim_id in REQUIRED_CLAIM_IDS
+              if claim_id not in heading_ids or claim_id not in claim_ids
+          ]
+          if missing_required_claim_ids:
+              fail(
+                  "required claim-id missing from docs/evidence.md: "
+                  + ", ".join(missing_required_claim_ids)
+                  + " (contract A-5; removing a required entry needs owner approval)"
+              )
 
           heading_id_set = set(heading_ids)
           for claim_id in claim_ids:


### PR DESCRIPTION
Closes #41 (Epic #24 follow-up F2; ordered after #57 per tracking #56).

## What
`evidence-freshness` job now fails when any of the required claim-ids (`EV-001..EV-004`, contract A-5) is missing from `docs/evidence.md` — checked both as a `## EV-xxx` heading and as a parsed `claim-id` entry. An emptied required set is also a hard fail (fail-closed). Constant carries the owner-approval guard comment.

## File manifest (L0-6)
`.github/workflows/family-links.yml` — 1 file, +20 lines, single commit.

## Verification (local, negative-tested)
- real evidence.md → exit 0 (5 entries incl. EV-007)
- EV-004 section deleted → **FAIL: required claim-id missing … EV-004 (contract A-5 …)** exit 1
- heading kept, claim-id row deleted → FAIL exit 1 (entry-side check)
- REQUIRED_CLAIM_IDS emptied → FAIL exit 1
- actionlint → 0 findings

Writer: Codex Sol (requested=actual). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)