### PR TITLE
build: Makefile test/lint entry points (#59)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.POSIX:
+
+# Test entry point (family decision 4, issue #59). Wraps the existing
+# checks — the scripts themselves are canonical; do not add logic here.
+test:
+	python3 -B tools/selftest_check_registry.py
+	python3 -B tools/selftest_family_footer.py
+	python3 -B tools/check_publication_gate.py --selftest
+	python3 -B tools/check_registry.py --offline
+	python3 -B tools/render.py --check
+
+# No lint tooling exists in this repo yet (stdlib-only python, no config).
+# Kept as an explicit no-op so `make lint` is a stable entry point for CI.
+lint:
+	@echo "lint: no lint tooling configured for this repo (no-op)"
+
+.PHONY: test lint


### PR DESCRIPTION
Closes #59 (campaign #56, B2; prerequisite for B6 test-lint caller).

## What
New root `Makefile` (wrap-only, POSIX): `make test` = selftest_check_registry → selftest_family_footer → check_publication_gate --selftest → check_registry --offline → render --check, stops at first failure. `make lint` = explicit no-op with honest comment (no lint tooling exists). No existing file modified.

## Verification (local)
- `make test` → exit 0 (all five checks green, output in order)
- Gate proof: /tmp copy with registry/modules.json renamed → `make test` exit 2 (non-zero, gate holds)
- `make lint` → exit 0 with no-op message

## File manifest (L0-6)
`Makefile` (new) — 1 file, single commit.

Parallel-GO note (L2-4): ran alongside #49 (README×4) — file sets disjoint.

Writer: Codex Sol (requested=actual). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)