### PR TITLE
docs: date the stale module count in evidence.md EV-001 (#67)

### DIFF
--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -13,7 +13,7 @@ Weekly CI flags stale evidence, humans edit this file, and CI never edits it.
 | claim-id | EV-001 |
 | believe | A map that claims to check reality must fail when it cannot see reality. |
 | built | Weekly registry checker `tools/check_registry.py` runs anonymously and, since PR #1, fails closed when the check cannot complete. |
-| actually happened | The initial checker silently skipped every module under anonymous API rate limiting yet printed OK with exit 0. One reviewer run skipped 5 of the 8 modules registered at the time (2026-08-12; 9 as of 2026-08-19). The fix moved to HTML checks and added `--require-reality` for the scheduled run. |
+| actually happened | The initial checker silently skipped every module under anonymous API rate limiting yet printed OK with exit 0. One reviewer run skipped 5 of the 8 modules then in the registry (measured 2026-08-05, PR #1; the registry has held 9 since 2026-08-07 and holds 9 as of 2026-08-19). The fix moved to HTML checks and added `--require-reality` for the scheduled run. |
 | still don't know | Whether every future fail-open shape is covered. See EV-002. |
 | state (delivery · visibility · evidence) | implemented · published · observed |
 | evidence | primary: https://github.com/caty-ai/family-os/pull/1 ; related (different failure family): https://github.com/caty-ai/.github/pull/12 (hand-edited generated SVGs were detected as generator drift and resynced with determinism proof) |

--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -13,7 +13,7 @@ Weekly CI flags stale evidence, humans edit this file, and CI never edits it.
 | claim-id | EV-001 |
 | believe | A map that claims to check reality must fail when it cannot see reality. |
 | built | Weekly registry checker `tools/check_registry.py` runs anonymously and, since PR #1, fails closed when the check cannot complete. |
-| actually happened | The initial checker silently skipped every module under anonymous API rate limiting yet printed OK with exit 0. One reviewer run skipped 5 of 8. The fix moved to HTML checks and added `--require-reality` for the scheduled run. |
+| actually happened | The initial checker silently skipped every module under anonymous API rate limiting yet printed OK with exit 0. One reviewer run skipped 5 of the 8 modules registered at the time (2026-08-12; 9 as of 2026-08-19). The fix moved to HTML checks and added `--require-reality` for the scheduled run. |
 | still don't know | Whether every future fail-open shape is covered. See EV-002. |
 | state (delivery · visibility · evidence) | implemented · published · observed |
 | evidence | primary: https://github.com/caty-ai/family-os/pull/1 ; related (different failure family): https://github.com/caty-ai/.github/pull/12 (hand-edited generated SVGs were detected as generator drift and resynced with determinism proof) |


### PR DESCRIPTION
Closes #67 (campaign #56, B3).

## What
EV-001 'actually happened': `One reviewer run skipped 5 of 8.` → `One reviewer run skipped 5 of the 8 modules registered at the time (2026-08-12; 9 as of 2026-08-19).` Both counts are now dated — no floating registry-size claims remain.

## Sweep proof (Done-when)
`grep -nE "of [0-9]+|[0-9]+ (module|modules|repositories)" docs/evidence.md` → the EV-001 line above is the only registry-size mention; other numbers in the file are run/PR counts, not registry sizes. Registry actual: `len(modules)` = 9 (matches the dated current value).

## File manifest (L0-6)
docs/evidence.md — 1 file, 1 line, single commit (+ 1-word Alpha final-inspection refinement: dated the current count too, so it cannot drift).

## Verification
`make test` exit 0 (all five checks) / evidence-freshness inline script green (row format intact).

Writer: Codex Sol (requested=actual); final inspection tweak by Alpha (dated '9 as of 2026-08-19' instead of undated 'today'). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)