### PR TITLE
docs: badge grammar — install badge to lightgrey (#60)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@
 
 [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-![install](https://img.shields.io/badge/install-not%20required-brightgreen)
+![install](https://img.shields.io/badge/install-not%20required-lightgrey)
 
 AIエージェントを増やすほど、記憶はばらばらになり、仕事は取りこぼされ、<br>
 育てたはずの経験は次のセッションで消えます。<br>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-![install](https://img.shields.io/badge/install-not%20required-brightgreen)
+![install](https://img.shields.io/badge/install-not%20required-lightgrey)
 
 The more AI agents you add, the more their memory scatters, the more work slips<br>
 through the cracks, and the more of what they learned vanishes at the next session.<br>

--- a/README.th.md
+++ b/README.th.md
@@ -15,7 +15,7 @@
 
 [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-![install](https://img.shields.io/badge/install-not%20required-brightgreen)
+![install](https://img.shields.io/badge/install-not%20required-lightgrey)
 
 ยิ่งเพิ่มเอเจนต์ AI มากเท่าไร ความทรงจำก็ยิ่งกระจัดกระจาย งานยิ่งหล่นหาย<br>
 และประสบการณ์ที่อุตส่าห์สั่งสมมาก็หายไปในเซสชันถัดไป<br>

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@
 
 [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-![install](https://img.shields.io/badge/install-not%20required-brightgreen)
+![install](https://img.shields.io/badge/install-not%20required-lightgrey)
 
 AI 智能体越多，记忆就越分散，工作越容易被漏掉，<br>
 好不容易积累的经验也会在下一次会话中消失。<br>


### PR DESCRIPTION
Closes #60 (campaign #56, B4).

## What
Install badge `brightgreen` → `lightgrey` in all 4 READMEs (1 line each). Wording/position/alt intact; license-MIT-blue and logo colors untouched; no live badges affected.

## Verification (local)
`grep -c brightgreen README*.md` → 0/0/0/0 · `make test` exit 0 · no other static green fact-badges found.

## File manifest (L0-6)
README.md / README.ja.md / README.zh.md / README.th.md — 4 files, 4 lines, single commit.

Writer: Codex Sol (requested=actual). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)