### PR TITLE
ci: gitleaks + history-check callers @ci-v1 (#61)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,9 @@
+name: gitleaks
+on:
+  pull_request:
+permissions: {contents: read}
+concurrency: {group: 'gitleaks-${{ github.event.pull_request.number }}', cancel-in-progress: true}
+jobs:
+  gitleaks:
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-gitleaks.yml@ci-v1
+    permissions: {contents: read}

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -1,0 +1,9 @@
+name: History Check
+on:
+  pull_request:
+permissions: {contents: read}
+concurrency: {group: 'history-check-${{ github.event.pull_request.number }}', cancel-in-progress: true}
+jobs:
+  history-check:
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-history-check.yml@ci-v1
+    permissions: {contents: read}


### PR DESCRIPTION
Closes #61 (campaign #56, B5; gate handbook#80 merged, ci-v1 = ad8bf76).

## What
Two NEW 9-line callers, byte-identical to `family-dev-handbook/templates/ci/{gitleaks,history-check}.yml`: pinned `@ci-v1`, `permissions: {contents: read}`, PR-number concurrency. Zero scan logic in this repo.

## Event-trigger reconciliation (Done-when の push 側)
Reusable sources hard-require the pull_request event (`Require pull_request event` guard failing on any other event_name) and depend on PR context (`github.base_ref`, `pull_request.head.sha`) — **PR-only by W0-3 canonical design**. Push trigger deliberately NOT added (a push run would either error or silently skip = fake green). The completion record will mark the push half N/A with this line evidence.

## Verification (local)
actionlint 0 findings / YAML parse ok / template diff = byte-identical ×2 / git status = exactly the 2 new files. **This PR itself is the first real run of both callers** — run URLs go into the completion record.

## File manifest (L0-6)
.github/workflows/gitleaks.yml / .github/workflows/history-check.yml — 2 new files, single commit.

Writer: Codex Sol (requested=actual). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)