### PR TITLE
ci: test-lint caller @ci-v1 (#65)

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,0 +1,11 @@
+name: Test + Lint
+on:
+  pull_request:
+permissions: {contents: read}
+concurrency: {group: 'test-lint-${{ github.event.pull_request.number }}', cancel-in-progress: true}
+jobs:
+  test-lint:
+    uses: caty-ai/family-dev-handbook/.github/workflows/reusable-test-lint.yml@ci-v1
+    permissions: {contents: read}
+    with:
+      run_macos: true


### PR DESCRIPTION
Closes #65 (campaign #56, B6; gates handbook#80 ✅ / #59 B2 ✅).

## What
One NEW caller `.github/workflows/test-lint.yml`, byte-identical to `templates/ci/test-lint.yml`: @ci-v1 pin, contents:read, PR concurrency, `run_macos: true`. The reusable runs this repo's `make test` / `make lint` (from #59) on ubuntu + macos.

## Contract reconciliation
- `require_suite_reconciliation` left default `false`: our `make test` does not yet emit the T-6 `suites: declared/executed/skipped` line — the reusable emits `::notice::` and passes (per templates/ci/README.md:34); flipping to true belongs to a future T-6 adoption lane, not B6.
- `run_macos: true` kept: repo checks are stdlib-python & OS-portable; support table claims macOS; no conflict with family-links.yml's separate macOS registry job (different workflows, complementary coverage).
- Local proof: `make test` exit 0 / `make lint` exit 0 in the worktree (what CI will run). **This PR is the caller's first real run.**

## File manifest (L0-6)
.github/workflows/test-lint.yml — 1 new file, single commit.

Writer: Codex Sol (requested=actual). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)