### PR TITLE
docs: CONTRIBUTING prerequisites + README Project status x4 (#64)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,19 @@ If you are unsure which side a report falls on, open it here and we will move it
 - **Keep implemented and planned separate.** The map is useful only because a reader can tell what exists today from what is still ahead. Never blur that line to make a section read better.
 - **Honest completion.** A change is done when its stated done-conditions pass with evidence, not when it looks done. Pull requests should list which conditions passed and how they were checked.
 
+## Prerequisites
+
+- `git`
+- GNU `make` or BSD `make`
+- Python 3.9+ using only the standard library; do not install anything with `pip`
+- Network access only if you intentionally run `python3 -B tools/check_registry.py` without `--offline`
+- `actionlint` if your change edits files under `.github/workflows/` (optional, but recommended)
+
 ## Checking your change
 
-There is no build and no test suite. Before opening a pull request, confirm:
+The repository entry point is `make test`. It runs the documented stdlib-only checks for the registry, README footer contract, publication gate, and generated render output. `make lint` is currently a documented no-op, kept as a stable CI entry point while no lint tool is configured.
+
+Before opening a pull request, run `make test`, optionally run `make lint`, and confirm these additional manual checks:
 
 - Every relative link and in-page anchor resolves.
 - Images referenced from the README exist and carry no embedded metadata.

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,6 +36,7 @@ Family OS は、その一つひとつに効く仕組みが**どこにあるか**
 - [1体のAIを育てる縦軸](#vertical)
 - [家族をつなぐ横軸](#horizontal)
 - [使うのに必要なもの](#environments)
+- [プロジェクトの状態](#project-status)
 - [最初の一歩](#get-started)
 - [変えない約束](#promises)
 - [もっと詳しく](#shelf)
@@ -268,6 +269,17 @@ Family OS の地図そのものを読むのに、特別な準備は要りませ�
 > **メモ:** 「実運用が確認できている」は、その環境で関連する仕組みを実際に動かしているという意味で、Family OS の全モジュールへの完全対応を保証するものではありません。2026-08-19 時点の実測です。モジュールごとの対応状況は、選んだリポジトリの README を正本として確認してください。
 
 動く見込みが立ったら、あとは1本選んで進むだけです。
+
+---
+
+<a id="project-status"></a>
+
+## プロジェクトの状態
+
+**Maturity:** `product` — Family OS は生きたファミリーマップであり、[docs/engineering.md](docs/engineering.md) にあるレジストリの maturity 語彙で公開しています。
+**CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
+**確認済み環境:** レジストリ検査とリンク検査は、変更のたびに Ubuntu と macOS の CI で回ります。地図そのものは Markdown を読める環境ならどこでも開けます。
+**既知の制約:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) は self-growth cycle の公開された一次記録がまだないため未検証のままです。[EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) が示す通り、週次の scheduled reality check はまだ若く、履歴上の scheduled run は現時点で1回です。
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -278,8 +278,8 @@ Family OS の地図そのものを読むのに、特別な準備は要りませ�
 
 **Maturity:** `product` — Family OS は生きたファミリーマップであり、[docs/engineering.md](docs/engineering.md) にあるレジストリの maturity 語彙で公開しています。
 **CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
-**確認済み環境:** レジストリ検査とリンク検査は、変更のたびに Ubuntu と macOS の CI で回ります。地図そのものは Markdown を読める環境ならどこでも開けます。
-**既知の制約:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) は self-growth cycle の公開された一次記録がまだないため未検証のままです。[EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) が示す通り、週次の scheduled reality check はまだ若く、履歴上の scheduled run は現時点で1回です。
+**確認済み環境:** レジストリ検査は変更のたびに Ubuntu と macOS の CI で回り、リンク検査とフッター検査は Ubuntu で回ります。地図そのものは Markdown を読める環境ならどこでも開けます。
+**既知の制約:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) は self-growth cycle の公開された一次記録がまだないため未検証のままです。[EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) が示す通り、週次の scheduled reality check はまだ若く、scheduled run の履歴もまだ短いままです。直近レビュー時点の件数と根拠はそのエントリにあります。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ Once you know it will run, all that is left is to pick one thread and follow it.
 
 **Maturity:** `product` — Family OS is a living family map, using the registry maturity vocabulary described in [docs/engineering.md](docs/engineering.md).
 **CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
-**Verified environments:** registry and link tooling run in CI on every change across Ubuntu and macOS; the map itself is readable in any Markdown renderer.
-**Known constraints:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) remains unverified because no public primary self-growth cycle record has been published; [EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) shows the weekly scheduled reality check is still young, with one scheduled run in history so far.
+**Verified environments:** registry checks run in CI on every change across Ubuntu and macOS; link and footer checks run on Ubuntu; the map itself is readable in any Markdown renderer.
+**Known constraints:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) remains unverified because no public primary self-growth cycle record has been published; [EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) shows the weekly scheduled reality check is still young and the scheduled-run history remains short; the current count and evidence as of the last review live in the entry.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Every part runs on its own, so you can take just the one you need today.
 - [The vertical axis: growing one agent](#vertical)
 - [The horizontal axis: connecting the family](#horizontal)
 - [What you need](#environments)
+- [Project status](#project-status)
 - [Your first step](#get-started)
 - [What will not change](#promises)
 - [Learn more](#shelf)
@@ -268,6 +269,17 @@ Reading the Family OS map itself takes no preparation at all.
 > **Note:** "In real use" means the related mechanisms are actually being run in that environment; it is not a guarantee of full support for every Family OS module. Measured 2026-08-19. For per-module support, treat the README of the repository you choose as canonical.
 
 Once you know it will run, all that is left is to pick one thread and follow it.
+
+---
+
+<a id="project-status"></a>
+
+## Project status
+
+**Maturity:** `product` — Family OS is a living family map, using the registry maturity vocabulary described in [docs/engineering.md](docs/engineering.md).
+**CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
+**Verified environments:** registry and link tooling run in CI on every change across Ubuntu and macOS; the map itself is readable in any Markdown renderer.
+**Known constraints:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) remains unverified because no public primary self-growth cycle record has been published; [EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) shows the weekly scheduled reality check is still young, with one scheduled run in history so far.
 
 ---
 

--- a/README.th.md
+++ b/README.th.md
@@ -36,6 +36,7 @@ Family OS คือแผนที่ที่บอกว่ากลไกซ�
 - [แกนตั้ง: เลี้ยง AI หนึ่งตัวให้โต](#vertical)
 - [แกนนอน: เชื่อมครอบครัวเข้าด้วยกัน](#horizontal)
 - [สิ่งที่ต้องมี](#environments)
+- [สถานะโครงการ](#project-status)
 - [ก้าวแรก](#get-started)
 - [สัญญาที่จะไม่เปลี่ยน](#promises)
 - [อ่านเพิ่มเติม](#shelf)
@@ -268,6 +269,17 @@ flowchart TB
 > **หมายเหตุ:** "ยืนยันการใช้งานจริงแล้ว" หมายถึงเราได้รันกลไกที่เกี่ยวข้องในสภาพแวดล้อมนั้นจริง ไม่ได้รับประกันว่าทุกโมดูลของ Family OS จะรองรับอย่างสมบูรณ์ เป็นผลวัดจริง ณ วันที่ 2026-08-19 สำหรับสถานะการรองรับรายโมดูล ให้ยึด README ของรีโปที่คุณเลือกเป็นฉบับหลัก
 
 เมื่อมั่นใจว่ามันทำงานได้แล้ว ที่เหลือก็แค่เลือกหนึ่งเส้นทางแล้วเดินต่อ
+
+---
+
+<a id="project-status"></a>
+
+## สถานะโครงการ
+
+**Maturity:** `product` — Family OS คือแผนที่ครอบครัวที่มีการดูแลต่อเนื่อง และรีโปนี้เผยแพร่ด้วยคำศัพท์ maturity ของ registry ตามที่อธิบายใน [docs/engineering.md](docs/engineering.md)
+**CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
+**สภาพแวดล้อมที่ยืนยันแล้ว:** เครื่องมือเช็ก registry และลิงก์รันบน CI ทุกครั้งที่มีการเปลี่ยนแปลง ทั้งบน Ubuntu และ macOS; ตัวแผนที่เองอ่านได้ด้วย Markdown renderer ใดก็ได้
+**ข้อจำกัดที่ทราบ:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) ยังไม่ผ่านการยืนยัน เพราะยังไม่มีบันทึกปฐมภูมิของ self-growth cycle ที่เผยแพร่สู่สาธารณะ; [EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) ระบุว่า weekly scheduled reality check ยังใหม่ และตอนนี้มีประวัติ scheduled run เพียงครั้งเดียว
 
 ---
 

--- a/README.th.md
+++ b/README.th.md
@@ -278,8 +278,8 @@ flowchart TB
 
 **Maturity:** `product` — Family OS คือแผนที่ครอบครัวที่มีการดูแลต่อเนื่อง และรีโปนี้เผยแพร่ด้วยคำศัพท์ maturity ของ registry ตามที่อธิบายใน [docs/engineering.md](docs/engineering.md)
 **CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
-**สภาพแวดล้อมที่ยืนยันแล้ว:** เครื่องมือเช็ก registry และลิงก์รันบน CI ทุกครั้งที่มีการเปลี่ยนแปลง ทั้งบน Ubuntu และ macOS; ตัวแผนที่เองอ่านได้ด้วย Markdown renderer ใดก็ได้
-**ข้อจำกัดที่ทราบ:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) ยังไม่ผ่านการยืนยัน เพราะยังไม่มีบันทึกปฐมภูมิของ self-growth cycle ที่เผยแพร่สู่สาธารณะ; [EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) ระบุว่า weekly scheduled reality check ยังใหม่ และตอนนี้มีประวัติ scheduled run เพียงครั้งเดียว
+**สภาพแวดล้อมที่ยืนยันแล้ว:** การตรวจ registry รันบน CI ทุกครั้งที่มีการเปลี่ยนแปลงทั้งบน Ubuntu และ macOS; การตรวจลิงก์และ footer รันบน Ubuntu; ตัวแผนที่เองอ่านได้ด้วย Markdown renderer ใดก็ได้
+**ข้อจำกัดที่ทราบ:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) ยังไม่ผ่านการยืนยัน เพราะยังไม่มีบันทึกปฐมภูมิของ self-growth cycle ที่เผยแพร่สู่สาธารณะ; [EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) ระบุว่า weekly scheduled reality check ยังใหม่ และประวัติ scheduled run ก็ยังสั้นอยู่; จำนวนครั้งปัจจุบันและหลักฐาน ณ ตอนรีวิวล่าสุดอยู่ใน entry นั้น
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -36,6 +36,7 @@ Family OS 是一张地图，告诉你解决每一个问题的部件**在哪里**
 - [培养一个 AI 的纵轴](#vertical)
 - [连接家族的横轴](#horizontal)
 - [使用前需要什么](#environments)
+- [项目状态](#project-status)
 - [第一步](#get-started)
 - [不会改变的承诺](#promises)
 - [了解更多](#shelf)
@@ -268,6 +269,17 @@ flowchart TB
 > **备注:** 「已在实际运行中确认」指的是我们确实在该环境里运行了相关机制，并不保证 Family OS 的全部模块都完全适配。数据为 2026-08-19 时点的实测。各模块的适配情况，请以你所选仓库的 README 为准。
 
 确认能跑起来之后，剩下的就是挑一条线走下去。
+
+---
+
+<a id="project-status"></a>
+
+## 项目状态
+
+**Maturity:** `product` — Family OS 是一张持续维护的家族地图，这个仓库按 [docs/engineering.md](docs/engineering.md) 中注册表的 maturity 语汇对外发布。
+**CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
+**已验证环境:** 注册表与链接检查会在每次变更时于 Ubuntu 和 macOS 的 CI 上运行；这张地图本身可在任何 Markdown 渲染器中阅读。
+**已知限制:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) 仍未验证，因为尚未公开 self-growth cycle 的第一手记录；[EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) 说明每周 scheduled reality check 还很新，历史上目前只有一次 scheduled run。
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -278,8 +278,8 @@ flowchart TB
 
 **Maturity:** `product` — Family OS 是一张持续维护的家族地图，这个仓库按 [docs/engineering.md](docs/engineering.md) 中注册表的 maturity 语汇对外发布。
 **CI:** [![family links](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/family-links.yml) [![Test + Lint](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml/badge.svg)](https://github.com/caty-ai/family-os/actions/workflows/test-lint.yml)
-**已验证环境:** 注册表与链接检查会在每次变更时于 Ubuntu 和 macOS 的 CI 上运行；这张地图本身可在任何 Markdown 渲染器中阅读。
-**已知限制:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) 仍未验证，因为尚未公开 self-growth cycle 的第一手记录；[EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) 说明每周 scheduled reality check 还很新，历史上目前只有一次 scheduled run。
+**已验证环境:** 注册表检查会在每次变更时于 Ubuntu 和 macOS 的 CI 上运行；链接与页脚检查在 Ubuntu 上运行；这张地图本身可在任何 Markdown 渲染器中阅读。
+**已知限制:** [EV-004](docs/evidence.md#ev-004--governed-self-growth-cycle--the-mechanism-is-public-no-cycle-record-is) 仍未验证，因为尚未公开 self-growth cycle 的第一手记录；[EV-003](docs/evidence.md#ev-003--the-weekly-reality-check-has-run-on-schedule-and-passed) 说明每周 scheduled reality check 还很新，scheduled run 的历史仍然很短；最近一次审查时的当前次数和证据记录在该条目中。
 
 ---
 


### PR DESCRIPTION
Closes #64 (campaign #56, B8; serial after B1/#58 ✅ and B4/#60 ✅).

## What
- **CONTRIBUTING.md**: fixes the now-false 'There is no build and no test suite' (false since #59) — entry point is `make test` (5 stdlib checks) / `make lint` (documented no-op); new **Prerequisites** section (git, make, Python 3.9+ stdlib-only; network only for the optional online registry check; actionlint optional for workflow edits)
- **README ×4**: new `## Project status` section in the PGL standard shape — maturity line (`product`), live CI badges (family-links + Test/Lint), verified environments (ubuntu+macOS in CI), honest known constraints (EV-004 unverified / EV-003 young) — same position (after What you need) and TOC entry in all four languages

## Verification (local)
`make test` exit 0 (publication gate + render blocks untouched) / `check_registry --offline` exit 0 (status-text clean) / TOC+anchor parity ×4 grep-proven.

## File manifest (L0-6)
CONTRIBUTING.md / README.md / README.ja.md / README.zh.md / README.th.md — 5 files, +59/−1, single commit.

Note: this PR touches no risk paths (docs only) — Risk Review Gate should stay green/neutral; pr-size advisory at 59 lines.

On merge: **v0.3.0 bundle tag** fulfills the deferred releases of #44/#49/#60/#62 + this PR (public README/docs changes).

Writer: Codex Sol (requested=actual). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)