### PR TITLE
feat: evidence freshness warning workflow (#63)

### DIFF
--- a/.github/workflows/evidence-warning.yml
+++ b/.github/workflows/evidence-warning.yml
@@ -1,0 +1,89 @@
+name: evidence freshness warning
+
+on:
+  schedule:
+    # Mondays, 23:30 UTC. This is intentionally distinct from the family-links
+    # weekly reality check, which runs at 23:00 UTC on Sunday.
+    - cron: "30 23 * * 1"
+  workflow_dispatch:
+    inputs:
+      threshold_days:
+        description: Warn when an entry is this many days old
+        required: false
+        default: '60'
+        type: string
+
+concurrency:
+  group: evidence-freshness-warning
+  cancel-in-progress: false
+
+jobs:
+  evidence-warning:
+    name: evidence freshness warning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: detect evidence warnings
+        id: detector
+        env:
+          THRESHOLD_DAYS: ${{ inputs.threshold_days || '60' }}
+        run: |
+          output_path="$(mktemp)"
+          python3 -B tools/check_evidence_warning.py \
+            --threshold-days "$THRESHOLD_DAYS" \
+            --format github > "$output_path"
+          tab="$(printf '\t')"
+          if grep -q "^WARN${tab}" "$output_path"; then
+            {
+              echo "warnings<<EOF"
+              grep "^WARN${tab}" "$output_path"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+          rm -f "$output_path"
+
+      - name: file evidence freshness warning
+        if: steps.detector.outputs.warnings != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          WARNINGS: ${{ steps.detector.outputs.warnings }}
+        run: |
+          title="evidence freshness warning: entries approaching the 90-day limit"
+          body_path="$(mktemp)"
+          {
+            echo "The following public evidence entries are approaching the 90-day rule in \`docs/evidence.md\`."
+            echo
+            echo "| Claim ID | Last reviewed | Age (days) |"
+            echo "| --- | --- | ---: |"
+            printf '%s\n' "$WARNINGS" | while IFS="$(printf '\t')" read -r kind claim_id reviewed age_days; do
+              if [ "$kind" = "WARN" ]; then
+                printf '| %s | %s | %s |\n' "$claim_id" "$reviewed" "$age_days"
+              fi
+            done
+            echo
+            echo "Close this issue once every listed entry has been re-reviewed and its \`last-reviewed\` date updated."
+          } > "$body_path"
+
+          existing_issue="$(gh issue list \
+            --repo "$REPOSITORY" \
+            --state open \
+            --search "$title in:title" \
+            --json number,title \
+            --jq '[.[] | select(.title == "evidence freshness warning: entries approaching the 90-day limit")][0].number // empty')"
+
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" \
+              --repo "$REPOSITORY" \
+              --body-file "$body_path"
+            exit 0
+          fi
+
+          gh issue create \
+            --repo "$REPOSITORY" \
+            --title "$title" \
+            --body-file "$body_path"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ test:
 	python3 -B tools/selftest_check_registry.py
 	python3 -B tools/selftest_family_footer.py
 	python3 -B tools/check_publication_gate.py --selftest
+	python3 -B tools/selftest_check_evidence_warning.py
 	python3 -B tools/check_registry.py --offline
 	python3 -B tools/render.py --check
 

--- a/tools/check_evidence_warning.py
+++ b/tools/check_evidence_warning.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Warn when evidence reviews approach their expiry without blocking CI.
+
+This detector reports review dates that need attention; it is intentionally not
+the evidence freshness gate. Warnings deliberately return exit 0, and the
+workflow decides whether to file or update an issue. Parse and read failures
+return 2. The gate owns the 90-day validity rule, while this tool gives
+maintainers time to re-review entries before that boundary.
+
+Python 3.9+, standard library only.
+"""
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import sys
+
+
+HEADING_PATTERN = re.compile(r"^## (?P<claim_id>EV-\d{3})\b")
+ROW_PATTERN = re.compile(r"^\|(?P<left>[^|]+)\|(?P<right>[^|]+)\|$")
+DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class EvidenceWarningError(Exception):
+    """An evidence document cannot be safely interpreted."""
+
+
+def fail(message):
+    print("ERROR: %s" % message, file=sys.stderr)
+    return 2
+
+
+def parse_date(value, claim_id, field):
+    if not DATE_PATTERN.fullmatch(value):
+        raise EvidenceWarningError(
+            "%s has invalid %s %r; expected YYYY-MM-DD" % (claim_id, field, value)
+        )
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        raise EvidenceWarningError(
+            "%s has invalid %s %r; expected YYYY-MM-DD" % (claim_id, field, value)
+        )
+
+
+def headings(lines):
+    result = []
+    seen = set()
+    for index, raw_line in enumerate(lines):
+        match = HEADING_PATTERN.match(raw_line.strip())
+        if not match:
+            continue
+        claim_id = match.group("claim_id")
+        if claim_id in seen:
+            raise EvidenceWarningError("duplicate evidence heading for %s" % claim_id)
+        seen.add(claim_id)
+        result.append((index, claim_id))
+    if not result:
+        raise EvidenceWarningError("parsed 0 evidence entries")
+    return result
+
+
+def reviewed_value(lines, start, end, claim_id):
+    values = []
+    for raw_line in lines[start:end]:
+        match = ROW_PATTERN.match(raw_line.strip())
+        if not match:
+            continue
+        if match.group("left").strip() == "last-reviewed":
+            values.append(match.group("right").strip())
+    if not values:
+        raise EvidenceWarningError("%s is missing last-reviewed" % claim_id)
+    if len(values) != 1:
+        raise EvidenceWarningError("%s has duplicate last-reviewed rows" % claim_id)
+    return values[0]
+
+
+def parse_entries(document):
+    lines = document.splitlines()
+    section_headings = headings(lines)
+    entries = []
+    for position, (start, claim_id) in enumerate(section_headings):
+        end = (
+            section_headings[position + 1][0]
+            if position + 1 < len(section_headings)
+            else len(lines)
+        )
+        entries.append((claim_id, reviewed_value(lines, start + 1, end, claim_id)))
+    return entries
+
+
+def warnings(entries, threshold_days, as_of):
+    result = []
+    for claim_id, raw_reviewed in entries:
+        reviewed = parse_date(raw_reviewed, claim_id, "last-reviewed")
+        age_days = (as_of - reviewed).days
+        if age_days < 0:
+            raise EvidenceWarningError(
+                "%s has future last-reviewed %s relative to %s"
+                % (claim_id, reviewed.isoformat(), as_of.isoformat())
+            )
+        if age_days >= threshold_days:
+            result.append((claim_id, reviewed.isoformat(), age_days))
+    return result
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(
+        description="warn when docs/evidence.md review dates approach expiry"
+    )
+    parser.add_argument(
+        "--evidence",
+        type=Path,
+        default=Path("docs/evidence.md"),
+        help="evidence document (default: docs/evidence.md)",
+    )
+    parser.add_argument(
+        "--threshold-days",
+        type=int,
+        default=60,
+        help="warn at this review age or older (default: 60)",
+    )
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="UTC comparison date as YYYY-MM-DD (default: today)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("human", "github"),
+        default="human",
+        help="output format (default: human)",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = make_parser().parse_args(argv)
+    if args.threshold_days < 0:
+        return fail("--threshold-days must be non-negative")
+
+    try:
+        as_of = (
+            parse_date(args.as_of, "--as-of", "date")
+            if args.as_of is not None
+            else datetime.now(timezone.utc).date()
+        )
+        document = args.evidence.read_text(encoding="utf-8")
+        entries = parse_entries(document)
+        found = warnings(entries, args.threshold_days, as_of)
+    except (EvidenceWarningError, OSError, UnicodeError) as error:
+        return fail(str(error))
+
+    if not found:
+        print(
+            "OK: no evidence entries older than %d days (checked %d entries)"
+            % (args.threshold_days, len(entries))
+        )
+        return 0
+
+    for claim_id, reviewed, age_days in found:
+        if args.format == "github":
+            print("WARN\t%s\t%s\t%d" % (claim_id, reviewed, age_days))
+        else:
+            print(
+                "WARN %s: last-reviewed %s is %d days old"
+                % (claim_id, reviewed, age_days)
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/selftest_check_evidence_warning.py
+++ b/tools/selftest_check_evidence_warning.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Subprocess self-tests for the evidence warning detector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+CHECKER = Path(__file__).with_name("check_evidence_warning.py")
+
+
+def evidence(*reviewed_values):
+    document = "# Evidence\n"
+    for index, last_reviewed in enumerate(reviewed_values, start=1):
+        claim_id = "EV-%03d" % index
+        document += (
+            "\n## %s — fixture\n\n" % claim_id
+            + "| field | value |\n"
+            + "| --- | --- |\n"
+            + "| claim-id | %s |\n" % claim_id
+            + "| last-reviewed | %s |\n" % last_reviewed
+        )
+    return document
+
+
+def run_checker(root, document, arguments=()):
+    evidence_path = root / "docs" / "evidence.md"
+    evidence_path.parent.mkdir(exist_ok=True)
+    evidence_path.write_text(document, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, "-B", str(CHECKER)] + list(arguments),
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def test_fresh_ok():
+    with tempfile.TemporaryDirectory() as temporary:
+        result = run_checker(
+            Path(temporary),
+            evidence("2026-08-20", "2026-08-19"),
+            ("--as-of", "2026-08-20"),
+        )
+    check(result.returncode == 0, result.stderr)
+    check(
+        result.stdout == "OK: no evidence entries older than 60 days (checked 2 entries)\n",
+        result.stdout,
+    )
+
+
+def test_age_61_github_warning():
+    with tempfile.TemporaryDirectory() as temporary:
+        result = run_checker(
+            Path(temporary),
+            evidence("2026-06-20"),
+            ("--as-of", "2026-08-20", "--format", "github"),
+        )
+    check(result.returncode == 0, result.stderr)
+    check(result.stdout == "WARN\tEV-001\t2026-06-20\t61\n", result.stdout)
+
+
+def test_threshold_boundaries():
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        warning = run_checker(
+            root,
+            evidence("2026-06-21"),
+            ("--as-of", "2026-08-20", "--format", "github"),
+        )
+        fresh = run_checker(
+            root,
+            evidence("2026-06-22"),
+            ("--as-of", "2026-08-20", "--format", "github"),
+        )
+    check(warning.returncode == 0, warning.stderr)
+    check(warning.stdout == "WARN\tEV-001\t2026-06-21\t60\n", warning.stdout)
+    check(fresh.returncode == 0, fresh.stderr)
+    check(
+        fresh.stdout == "OK: no evidence entries older than 60 days (checked 1 entries)\n",
+        fresh.stdout,
+    )
+
+
+def test_malformed_date_fails_closed():
+    with tempfile.TemporaryDirectory() as temporary:
+        result = run_checker(Path(temporary), evidence("2026-02-30"))
+    check(result.returncode == 2, result.returncode)
+    check("EV-001" in result.stderr, result.stderr)
+
+
+def test_zero_entries_fails_closed():
+    with tempfile.TemporaryDirectory() as temporary:
+        result = run_checker(Path(temporary), "# Evidence\n")
+    check(result.returncode == 2, result.returncode)
+    check("parsed 0 evidence entries" in result.stderr, result.stderr)
+
+
+def main():
+    test_fresh_ok()
+    test_age_61_github_warning()
+    test_threshold_boundaries()
+    test_malformed_date_fails_closed()
+    test_zero_entries_fails_closed()
+    print("selftest_check_evidence_warning: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #63 (campaign #56 follow-up shelf; serial after #68 merged 30a2ebd).

## What
- `tools/check_evidence_warning.py`: parses docs/evidence.md entries (same grammar as the freshness gate), warns at `--threshold-days` (default 60) with `--as-of` for deterministic tests; detector-not-gate (warnings exit 0; parse failure exit 2 fail-closed); `--format github` = tab-separated for the workflow
- `tools/selftest_check_evidence_warning.py`: 5 cases (fresh / 61d / boundary 60=WARN·59=no / malformed date exit 2 / zero entries exit 2), wired into `make test`
- `.github/workflows/evidence-warning.yml`: Mondays 23:30 UTC (offset from family-links) + workflow_dispatch `threshold_days` input; issues:write; fixed-title issue with exact-title dedupe (comments on the existing one); script failure = red step
- Makefile: selftest line added

## Verification (local)
selftest ok / real evidence.md → `OK … (checked 5 entries)` / `--threshold-days 1` → 5 WARN lines (detection live-proof) / make test exit 0 / actionlint 0.

## Post-merge live filing proof (Done-when 4)
Orchestrator will run `workflow_dispatch threshold_days=1` → the warning issue gets filed with all 5 entries → record run URL + issue number in the completion record → close the test-filed issue.

## Risk Review Gate (expected)
Touches tools/** + .github/workflows/** → gate red until @shojikumaru applies `risk-reviewed` (2nd live cycle).

## File manifest (L0-6)
tools/check_evidence_warning.py / tools/selftest_check_evidence_warning.py / .github/workflows/evidence-warning.yml / Makefile — 4 files, single commit.

Writer: Codex Sol (requested=actual). Review: 3 seats to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)