### PR TITLE
registry: drop stale persona-engine readme_overrides (#87)

### DIFF
--- a/registry/modules.json
+++ b/registry/modules.json
@@ -327,9 +327,6 @@
         "group": "vertical",
         "foundation": false
       },
-      "readme_overrides": {
-        "README.zh-CN.md": "zh"
-      },
       "license": "MIT",
       "class": {
         "en": "runtime, standalone",


### PR DESCRIPTION
Closes #87. Campaign: caty-ai/family-os#56 (unblocks the PEN column of B1).

## What

Remove the stale `readme_overrides: {"README.zh-CN.md": "zh"}` from the `caty-ai/persona-engine` entry in `registry/modules.json`. persona-engine#21 (B12, merged 2026-08-19) renamed `README.zh-CN.md` → `README.zh.md`, so persona-engine now has the standard 4-README set and the override is dead — worse than dead: `family_footer.py render` fails closed on it (`marker-carrying README.zh.md is not in the declared README set`), blocking persona-engine#19 (B1 footer sync).

## Done when → evidence

1. **`readme_overrides` removed from the persona-engine entry** — the diff is exactly the 3-line key removal; `grep -c readme_overrides registry/modules.json` → 0 (no other entry used the key).
2. **`family_footer.py render --repo caty-ai/persona-engine` completes against a current persona-engine checkout** — run from this branch against persona-engine main `770b1e2`:
   ```
   updated: README.md
   updated: README.ja.md
   updated: README.zh.md
   updated: README.th.md
   exit=0
   ```
   The rendered diff is footer-block-only, 4 files × ±4 lines (PGL row → published/linked, context-kit tagline sync). The persona-engine checkout was reset afterwards — committing that diff is persona-engine#19's job, on its own lane.
3. `python3 -m json.tool registry/modules.json` parses; `family_footer.py lint` → `OK — family footer registry is self-consistent.`

## Files touched (= WIP declaration)

- `registry/modules.json` (persona-engine entry only)

## Notes for review

- Size S, 3-seat review (GLM + rotation).
- `registry/**` is in this repo's declared `risk_paths_gates` → risk-review-gate will ask for the owner `risk-reviewed` label; the label request goes out after seat review confirms no further commits are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
