### PR TITLE
registry: flip alpha-nightshift to published, footer:true — E1 publication pilot (#96)

### DIFF
--- a/FOR-AGENTS.md
+++ b/FOR-AGENTS.md
@@ -66,6 +66,7 @@ For each repository: its role in one line, and the one thing to verify. These ar
 | [self-growth-loop](https://github.com/caty-ai/self-growth-loop) (published, MIT) | the loop for independent growth of ability (propose → trial → council → human approval → adopt) | that no code path reaches "adopt" without human approval |
 | [family-memory-architecture](https://github.com/caty-ai/family-memory-architecture) (published, MIT) | the horizontal axis where a family shares memory (single write path, provenance) | that there is a single write path and provenance records are kept |
 | [sitter](https://github.com/caty-ai/sitter) (published, MIT) | the watcher for long-running tasks (zero-dependency bash, stall detection) | that the monitoring runs with zero dependencies |
+| [alpha-nightshift](https://github.com/caty-ai/alpha-nightshift) (published, MIT) | the nightly autonomous maintenance loop — night lanes in isolated worktrees behind a deny-by-default guard; humans cherry-pick in the morning | that the guard denies publishing by default and results reach main only through a morning human cherry-pick |
 
 (Modules still being prepared for release are listed in the registry as `preparing`. They are not linked.)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -370,6 +370,7 @@ Family OS が広がっても、次の5つは変わりません。
 | 縦軸 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録 | 公開・MIT |
 | 横軸・基盤 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 記憶バス — 家族が知っていることを共有する層 | 公開・MIT |
 | 横軸 | [Sitter](https://github.com/caty-ai/sitter) | 委譲したエージェント実行の見張り番 — 監視・証拠の記録・宣言した範囲内でのみ再起動 | 公開・MIT |
+| 横軸 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | 夜間自律保守ループ — deny-by-default の guard の内側で夜のレーンが走り、朝は人間が cherry-pick するだけ | 公開・MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Every module on this map, with its current state — generated from the same reg
 | Vertical | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | Lets an agent grow its own abilities — proposals, governance, adoption records | published, MIT |
 | Horizontal · foundation | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | The memory bus — how the family shares what it knows | published, MIT |
 | Horizontal | [Sitter](https://github.com/caty-ai/sitter) | Babysits delegated agent runs — watches, keeps evidence, restarts only within declared bounds | published, MIT |
+| Horizontal | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | Nightly autonomous maintenance loop — isolated night lanes behind a deny-by-default guard; humans cherry-pick in the morning | published, MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.th.md
+++ b/README.th.md
@@ -370,6 +370,7 @@ flowchart TB
 | แกนตั้ง | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง — ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้ | เปิดแล้ว・MIT |
 | แกนนอน · รากฐาน | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้ | เปิดแล้ว・MIT |
 | แกนนอน | [Sitter](https://github.com/caty-ai/sitter) | พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ตเฉพาะในขอบเขตที่ประกาศไว้ | เปิดแล้ว・MIT |
+| แกนนอน | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | ลูปบำรุงรักษาอัตโนมัติยามค่ำคืน — เลนกลางคืนทำงานหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือก cherry-pick | เปิดแล้ว・MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -370,6 +370,7 @@ Family OS 这边没有要做的事。不用安装，不用注册账号，也没�
 | 纵轴 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | 让智能体自我成长的循环 — 提案、治理与采用记录 | 已公开・MIT |
 | 横轴・基座 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 记忆总线 — 家族共享所知的一层 | 已公开・MIT |
 | 横轴 | [Sitter](https://github.com/caty-ai/sitter) | 替你盯着委派出去的智能体 — 监视、留证、仅在声明范围内重启 | 已公开・MIT |
+| 横轴 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | 夜间自主维护循环 — 在默认拒绝的防护边界内运行夜间通道，早晨由人工挑选合并 | 已公开・MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -67,7 +67,7 @@ flowchart TB
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime・アプリケーション | 提案・ガバナンス・採用記録・成長の解釈 | 公開・MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime・横方向の基盤 | 記憶バス・登録されたスケジュールの期待・check-in・来歴 | 公開・MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime・観測 | ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動 | 公開・MIT |
-| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・自律運用ループ | 夜間の観測・実装・検証レーン、guard の publish 境界、morning triage | 公開準備中 |
+| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・自律運用ループ | 夜間の観測・実装・検証レーン、guard の publish 境界、morning triage | 公開・MIT |
 <!-- family:generated:module-inventory:end -->
 
 この表は [`registry/modules.json`](../registry/modules.json) から生成しています。「公開準備中」のリンクは、いまはまだ開けません。何が存在し、どこに置かれるのかを地図として正直に保つために載せています。

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -67,6 +67,7 @@ flowchart TB
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime・アプリケーション | 提案・ガバナンス・採用記録・成長の解釈 | 公開・MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime・横方向の基盤 | 記憶バス・登録されたスケジュールの期待・check-in・来歴 | 公開・MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime・観測 | ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動 | 公開・MIT |
+| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・自律運用ループ | 夜間の観測・実装・検証レーン、guard の publish 境界、morning triage | 公開準備中 |
 <!-- family:generated:module-inventory:end -->
 
 この表は [`registry/modules.json`](../registry/modules.json) から生成しています。「公開準備中」のリンクは、いまはまだ開けません。何が存在し、どこに置かれるのかを地図として正直に保つために載せています。

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -67,6 +67,7 @@ The rules layer sits **above** both axes rather than inside either one. It is a 
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime, application | proposal, governance, adoption records, growth interpretation | published, MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | published, MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime, observation | local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart | published, MIT |
+| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・autonomous ops loop | overnight observe/implement/verify lanes, the guard publish boundary, and morning triage | publication in preparation |
 <!-- family:generated:module-inventory:end -->
 
 This table is generated from [`registry/modules.json`](../registry/modules.json). Links marked *publication in preparation* cannot be opened yet. They are listed so the map stays honest about what exists and where it will live.

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -67,7 +67,7 @@ The rules layer sits **above** both axes rather than inside either one. It is a 
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime, application | proposal, governance, adoption records, growth interpretation | published, MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | published, MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime, observation | local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart | published, MIT |
-| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・autonomous ops loop | overnight observe/implement/verify lanes, the guard publish boundary, and morning triage | publication in preparation |
+| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・autonomous ops loop | overnight observe/implement/verify lanes, the guard publish boundary, and morning triage | published, MIT |
 <!-- family:generated:module-inventory:end -->
 
 This table is generated from [`registry/modules.json`](../registry/modules.json). Links marked *publication in preparation* cannot be opened yet. They are listed so the map stays honest about what exists and where it will live.

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -67,7 +67,7 @@ The rules layer sits **above** both axes rather than inside either one. It is a 
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime, application | proposal, governance, adoption records, growth interpretation | published, MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | published, MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime, observation | local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart | published, MIT |
-| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・autonomous ops loop | overnight observe/implement/verify lanes, the guard publish boundary, and morning triage | published, MIT |
+| [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime, autonomous ops loop | overnight observe/implement/verify lanes, the guard publish boundary, and morning triage | published, MIT |
 <!-- family:generated:module-inventory:end -->
 
 This table is generated from [`registry/modules.json`](../registry/modules.json). Links marked *publication in preparation* cannot be opened yet. They are listed so the map stays honest about what exists and where it will live.

--- a/docs/readme-visual-system.md
+++ b/docs/readme-visual-system.md
@@ -146,7 +146,7 @@ the generated block directly.
 | Self Growth Loop | `caty-ai/self-growth-loop` | published, MIT |
 | Family Memory Architecture | `caty-ai/family-memory-architecture` | published, MIT |
 | Sitter | `caty-ai/sitter` | published, MIT |
-| Alpha Nightshift | `caty-ai/alpha-nightshift` | publication in preparation |
+| Alpha Nightshift | `caty-ai/alpha-nightshift` | published, MIT |
 <!-- family:generated:repository-links:end -->
 
 ## Deliberate palette split

--- a/docs/readme-visual-system.md
+++ b/docs/readme-visual-system.md
@@ -146,6 +146,7 @@ the generated block directly.
 | Self Growth Loop | `caty-ai/self-growth-loop` | published, MIT |
 | Family Memory Architecture | `caty-ai/family-memory-architecture` | published, MIT |
 | Sitter | `caty-ai/sitter` | published, MIT |
+| Alpha Nightshift | `caty-ai/alpha-nightshift` | publication in preparation |
 <!-- family:generated:repository-links:end -->
 
 ## Deliberate palette split

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -332,6 +332,12 @@
           "ja": "夜間自律保守ループ。deny-by-default の guard の内側で観測・実装・検証レーンが隔離 worktree で走り、朝は人間が証明つきの結果だけを cherry-pick する",
           "zh": "夜间自主维护循环：观测・实现・验证通道在默认拒绝的防护边界内的隔离 worktree 中运行，早晨由人工挑选已验证的成果合并",
           "th": "ลูปบำรุงรักษาอัตโนมัติยามค่ำคืน: เลนสังเกต/พัฒนา/ตรวจสอบทำงานใน worktree แยกหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือกรับเฉพาะผลที่พิสูจน์แล้ว"
+        },
+        "desc_short": {
+          "en": "Nightly autonomous maintenance — night lanes behind a deny-by-default guard; humans cherry-pick in the morning",
+          "ja": "夜間の自律保守。deny-by-default の guard の内側で夜レーンが走り、朝は人間が cherry-pick するだけ",
+          "zh": "夜间自主维护——夜间通道在默认拒绝的防护内运行，早晨由人工挑选合并",
+          "th": "งานบำรุงรักษาอัตโนมัติยามค่ำคืน — เลนกลางคืนวิ่งหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือก cherry-pick"
         }
       }
     }
@@ -595,7 +601,7 @@
       "id": "alpha-nightshift",
       "name": "Alpha Nightshift",
       "repo": "caty-ai/alpha-nightshift",
-      "status": "preparing",
+      "status": "published",
       "maturity": "reference",
       "tagline": {
         "en": "Nightly autonomous maintenance loop — isolated night lanes behind a deny-by-default guard; humans cherry-pick in the morning",
@@ -616,7 +622,7 @@
         "en": "overnight observe/implement/verify lanes, the guard publish boundary, and morning triage",
         "ja": "夜間の観測・実装・検証レーン、guard の publish 境界、morning triage"
       },
-      "footer": false
+      "footer": true
     }
   ],
   "adjacent": [

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -324,6 +324,15 @@
           "zh": "看管已托付任务的执行。杜绝「托付的工作下落不明」",
           "th": "ผู้เฝ้าดูงานที่มอบหมายไป ป้องกัน 'งานที่ฝากไว้หายไปไหนไม่รู้'"
         }
+      },
+      "alpha-nightshift": {
+        "name": "alpha-nightshift",
+        "desc": {
+          "en": "A nightly autonomous maintenance loop: overnight observe/implement/verify lanes run in isolated worktrees behind a deny-by-default guard, and humans cherry-pick proven results in the morning",
+          "ja": "夜間自律保守ループ。deny-by-default の guard の内側で観測・実装・検証レーンが隔離 worktree で走り、朝は人間が証明つきの結果だけを cherry-pick する",
+          "zh": "夜间自主维护循环：观测・实现・验证通道在默认拒绝的防护边界内的隔离 worktree 中运行，早晨由人工挑选已验证的成果合并",
+          "th": "ลูปบำรุงรักษาอัตโนมัติยามค่ำคืน: เลนสังเกต/พัฒนา/ตรวจสอบทำงานใน worktree แยกหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือกรับเฉพาะผลที่พิสูจน์แล้ว"
+        }
       }
     }
   },
@@ -581,6 +590,33 @@
         "ja": "ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動"
       },
       "footer": true
+    },
+    {
+      "id": "alpha-nightshift",
+      "name": "Alpha Nightshift",
+      "repo": "caty-ai/alpha-nightshift",
+      "status": "preparing",
+      "maturity": "reference",
+      "tagline": {
+        "en": "Nightly autonomous maintenance loop — isolated night lanes behind a deny-by-default guard; humans cherry-pick in the morning",
+        "ja": "夜間自律保守ループ — deny-by-default の guard の内側で夜のレーンが走り、朝は人間が cherry-pick するだけ",
+        "zh": "夜间自主维护循环 — 在默认拒绝的防护边界内运行夜间通道，早晨由人工挑选合并",
+        "th": "ลูปบำรุงรักษาอัตโนมัติยามค่ำคืน — เลนกลางคืนทำงานหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือก cherry-pick"
+      },
+      "axis": {
+        "group": "horizontal",
+        "foundation": false
+      },
+      "license": "MIT",
+      "class": {
+        "en": "runtime・autonomous ops loop",
+        "ja": "runtime・自律運用ループ"
+      },
+      "owns": {
+        "en": "overnight observe/implement/verify lanes, the guard publish boundary, and morning triage",
+        "ja": "夜間の観測・実装・検証レーン、guard の publish 境界、morning triage"
+      },
+      "footer": false
     }
   ],
   "adjacent": [

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -615,7 +615,7 @@
       },
       "license": "MIT",
       "class": {
-        "en": "runtime・autonomous ops loop",
+        "en": "runtime, autonomous ops loop",
         "ja": "runtime・自律運用ループ"
       },
       "owns": {

--- a/tools/selftest_family_footer.py
+++ b/tools/selftest_family_footer.py
@@ -30,6 +30,7 @@ from family_footer import (
     lint_registry,
     load_registry,
     module_table,
+    published_modules,
     render_org_block,
     render_org_to_target,
     render_region,
@@ -1043,6 +1044,9 @@ def test_org_count_preparing_and_golden_bytes():
 
 
 def test_org_ja_intro_uses_counter_for_eleven():
+    # The live registry plus one fixture module must land in the double-digit
+    # regime, where the ja intro takes the 個 counter, never つ. Counted from
+    # the registry so a new published module does not invalidate this test.
     registry = load_registry()
     registry["modules"].append(
         {"id": "extra", "repo": "fixture/extra", "status": "published"}
@@ -1051,9 +1055,11 @@ def test_org_ja_intro_uses_counter_for_eleven():
         "name": "extra",
         "desc_short": {lang: "extra" for lang in registry["languages"]},
     }
+    count = len(published_modules(registry)) + 1
+    assert count >= 11
     rendered = render_org_block(registry, "ja")
-    assert "このうち11個は" in rendered
-    assert "このうち11つは" not in rendered
+    assert "このうち%d個は" % count in rendered
+    assert "このうち%dつは" % count not in rendered
 
 
 def test_org_degradation_and_svg_assertions():


### PR DESCRIPTION
## What

Flips the alpha-nightshift registry entry to `published` + `footer: true` (#96 flip-time follow-up), closing the publication rollout that began with the repo going public on 2026-08-23 (evidence: [completion record on -dev#46](https://github.com/caty-ai/alpha-nightshift-dev/issues/46#issuecomment-5385013253)).

Rollout annex (all MERGED before this PR, rendered from this PR's registry — byte-validity re-verified after every head move):

- caty-ai/alpha-nightshift#1 — footer install, 4 READMEs (merge `ab676c09`)
- Nine sibling re-renders: family-dev-handbook#124, caty-agent-harness#167, context-kit#45, persona-engine#41, persona-growth-loop#33, x-collector#66, self-growth-loop#43, family-memory-architecture#54, sitter#36
- caty-ai/.github#51 — org-profile markdown ×5 (SVGs deliberately untouched: post-#117 minimal profile bans module-id residue; 3/3 seats verified)

## Completion record (L1-7)

**Candidate SHA**: `6011c84d6be6907c41033b9aed903c3e8e13b017` (= PR head)
**Implementer**: Alpha (Claude Fable 5, session 70ff6d50, MBP) — direct md/json + S-size selftest fix, declared on the allow-list
**Reviewers (S/M 3 heterogeneous seats via loom-seats, blind, read-only, fresh context)**:
- Grok 4.6 (xAI) — GO, 0 CRITICAL / 0 MAJOR / 3 MINOR
- Kimi K3 (Moonshot) — GO, conditions: merge at the reviewed head line, closing `workflow_dispatch` mandatory, don't straddle the Monday cron
- GLM 5.3 (Zhipu) — GO, incl. a simulated post-rollout `check --require-reality` against all 11 rollout PR heads = **0 failures**
Seat findings adjudicated: PR title fixed; `class.en` separator normalized (`6011c84`, no cascade — render-all reports 15/15 unchanged); contract-doc SVG drift recorded on #119 (owned by that lane).

**Done when (from #96, flip-time items)**:
- status→published, footer→true — **PASS**: `registry/modules.json` diff in this PR; `org_profile` `desc_short` ×4 languages added (lint requires it at publish).
- `python3 tools/check_registry.py` green — **PASS**: local full-network run 2026-08-23 "OK — every module claim matches the registry" (tour A-8 row added to FOR-AGENTS.md §5); PR CI `registry matches reality` pass on `6011c84` (ubuntu + macOS).
- `python3 tools/family_footer.py lint` green — **PASS**: local run + PR CI `family footer` pass on `6011c84`.
- render + idempotence — **PASS**: `python3 tools/render.py --check` "generated content is up to date" (local + CI); GLM seat re-ran independently.

**Declared vs actual file set**: WIP declaration (2026-08-23 comment) declared registry/modules.json + rendered README×4 / docs×3 + rollout annex. Actual diff: those 9 files + FOR-AGENTS.md (tour row, required by contract A-8 at publish — CI-enforced) + tools/selftest_family_footer.py (live-registry-count fixture fix; the flip is unmergeable without it). Both additions recorded here as the L1-8 correction to the declaration.

**CI state**: all checks green on `6011c84` except `risk-review-gate` — awaiting roster-human `risk-reviewed` label for this head (registry/** is a declared risk path; the gate voids labels on every push, by design).

**Release**: `v0.9.0` (annotated tag + GitHub Release, created at merge — tenth published module).
**Previous release**: `v0.8.2`.

**Post-merge verification (Kimi MAJOR-2)**: `workflow_dispatch` of `family-links.yml` with `check --require-reality` immediately after merge, same day, before the Monday 23:00 UTC cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
