### PR TITLE
registry: register meetmate as a published module (#94)

### DIFF
--- a/FOR-AGENTS.md
+++ b/FOR-AGENTS.md
@@ -64,6 +64,7 @@ For each repository: its role in one line, and the one thing to verify. These ar
 | [persona-growth-loop](https://github.com/caty-ai/persona-growth-loop) (published, MIT) | grows the persona itself — minimal, idempotent proposals with a governed adoption path | that proposals are minimal and idempotent, and adoption is gated by approval |
 | [x-collector](https://github.com/caty-ai/x-collector) (published, MIT) | the sense organ gathering outside information (X/Reddit/RSS → daily digest) | that acquisition is a reproducible pipeline |
 | [self-growth-loop](https://github.com/caty-ai/self-growth-loop) (published, MIT) | the loop for independent growth of ability (propose → trial → council → human approval → adopt) | that no code path reaches "adopt" without human approval |
+| [meetmate](https://github.com/caty-ai/meetmate) (published, MIT) | gives your own agent a seat in the meeting as a voice participant (Google Meet, Zoom) | that the agent stays yours — the meeting path carries no model, memory, or persona of its own |
 | [family-memory-architecture](https://github.com/caty-ai/family-memory-architecture) (published, MIT) | the horizontal axis where a family shares memory (single write path, provenance) | that there is a single write path and provenance records are kept |
 | [sitter](https://github.com/caty-ai/sitter) (published, MIT) | the watcher for long-running tasks (zero-dependency bash, stall detection) | that the monitoring runs with zero dependencies |
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -367,6 +367,7 @@ Family OS が広がっても、次の5つは変わりません。
 | 縦軸 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | 人格そのものを育てる — 最小・冪等な提案づくり | 公開・MIT |
 | 縦軸 | [X Collector](https://github.com/caty-ai/x-collector) | Xやウェブの素材を1日1回のダイジェストに — 人にもエージェントにも | 公開・MIT |
 | 縦軸 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録 | 公開・MIT |
+| 縦軸 | [Meetmate](https://github.com/caty-ai/meetmate) | 自分の AI エージェントを会議へ — Google Meet と Zoom に声で参加する | 公開・MIT |
 | 横軸・基盤 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 記憶バス — 家族が知っていることを共有する層 | 公開・MIT |
 | 横軸 | [Sitter](https://github.com/caty-ai/sitter) | 委譲したエージェント実行の見張り番 — 監視・証拠の記録・再起動 | 公開・MIT |
 <!-- family:generated:family-table:end -->

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Every module on this map, with its current state — generated from the same reg
 | Vertical | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | Grows the persona itself — minimal, idempotent proposals | published, MIT |
 | Vertical | [X Collector](https://github.com/caty-ai/x-collector) | Turns X and the web into one daily digest — for people and agents | published, MIT |
 | Vertical | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | Lets an agent grow its own abilities — proposals, governance, adoption records | published, MIT |
+| Vertical | [Meetmate](https://github.com/caty-ai/meetmate) | Puts your own AI agent in the meeting — a real voice participant in Google Meet and Zoom | published, MIT |
 | Horizontal · foundation | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | The memory bus — how the family shares what it knows | published, MIT |
 | Horizontal | [Sitter](https://github.com/caty-ai/sitter) | Babysits delegated agent runs — watches, keeps evidence, restarts | published, MIT |
 <!-- family:generated:family-table:end -->

--- a/README.th.md
+++ b/README.th.md
@@ -367,6 +367,7 @@ flowchart TB
 | แกนตั้ง | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | พัฒนาบุคลิกของเอเจนต์ — สร้างข้อเสนอแบบน้อยที่สุดและทำซ้ำได้ | เปิดแล้ว・MIT |
 | แกนตั้ง | [X Collector](https://github.com/caty-ai/x-collector) | รวบรวมข้อมูลจาก X และเว็บเป็นสรุปวันละฉบับ — สำหรับคนและเอเจนต์ | เปิดแล้ว・MIT |
 | แกนตั้ง | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง — ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้ | เปิดแล้ว・MIT |
+| แกนตั้ง | [Meetmate](https://github.com/caty-ai/meetmate) | พาเอเจนต์ AI ของคุณเข้าประชุม — ผู้ร่วมประชุมด้วยเสียงจริงใน Google Meet และ Zoom | เปิดแล้ว・MIT |
 | แกนนอน · รากฐาน | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้ | เปิดแล้ว・MIT |
 | แกนนอน | [Sitter](https://github.com/caty-ai/sitter) | พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ต | เปิดแล้ว・MIT |
 <!-- family:generated:family-table:end -->

--- a/README.zh.md
+++ b/README.zh.md
@@ -367,6 +367,7 @@ Family OS 这边没有要做的事。不用安装，不用注册账号，也没�
 | 纵轴 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | 让人格本身成长 — 以最小且幂等的提案 | 已公开・MIT |
 | 纵轴 | [X Collector](https://github.com/caty-ai/x-collector) | 把 X 与网络素材汇成每日一份摘要 — 给人也给智能体 | 已公开・MIT |
 | 纵轴 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | 让智能体自我成长的循环 — 提案、治理与采用记录 | 已公开・MIT |
+| 纵轴 | [Meetmate](https://github.com/caty-ai/meetmate) | 让你的 AI 智能体入席会议 — 在 Google Meet 与 Zoom 中以真实语音参与 | 已公开・MIT |
 | 横轴・基座 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 记忆总线 — 家族共享所知的一层 | 已公开・MIT |
 | 横轴 | [Sitter](https://github.com/caty-ai/sitter) | 替你盯着委派出去的智能体 — 监视、留证、重启 | 已公开・MIT |
 <!-- family:generated:family-table:end -->

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -65,6 +65,7 @@ flowchart TB
 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | runtime・アプリケーション | 最小化された冪等な提案の生成 | 公開・MIT |
 | [X Collector](https://github.com/caty-ai/x-collector) | runtime・任意の入力 | 能力ループ向けの外部素材の収集 | 公開・MIT |
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime・アプリケーション | 提案・ガバナンス・採用記録・成長の解釈 | 公開・MIT |
+| [Meetmate](https://github.com/caty-ai/meetmate) | runtime・単独利用可能 | 会議への参加とエージェントの声の席 — 音声の入力と発話 | 公開・MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime・横方向の基盤 | 記憶バス・登録されたスケジュールの期待・check-in・来歴 | 公開・MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime・観測 | ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動 | 公開・MIT |
 <!-- family:generated:module-inventory:end -->

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -65,6 +65,7 @@ The rules layer sits **above** both axes rather than inside either one. It is a 
 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | runtime, application | minimised, idempotent proposal production | published, MIT |
 | [X Collector](https://github.com/caty-ai/x-collector) | runtime, optional input | collecting external material for the ability loop | published, MIT |
 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | runtime, application | proposal, governance, adoption records, growth interpretation | published, MIT |
+| [Meetmate](https://github.com/caty-ai/meetmate) | runtime, standalone | meeting attendance and the agent's voice seat — audio in, speech out | published, MIT |
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | published, MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime, observation | local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart | published, MIT |
 <!-- family:generated:module-inventory:end -->

--- a/docs/readme-visual-system.md
+++ b/docs/readme-visual-system.md
@@ -144,6 +144,7 @@ the generated block directly.
 | Persona Growth Loop | `caty-ai/persona-growth-loop` | published, MIT |
 | X Collector | `caty-ai/x-collector` | published, MIT |
 | Self Growth Loop | `caty-ai/self-growth-loop` | published, MIT |
+| Meetmate | `caty-ai/meetmate` | published, MIT |
 | Family Memory Architecture | `caty-ai/family-memory-architecture` | published, MIT |
 | Sitter | `caty-ai/sitter` | published, MIT |
 <!-- family:generated:repository-links:end -->

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -205,6 +205,15 @@
           "th": "วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้"
         }
       },
+      "meetmate": {
+        "name": "meetmate",
+        "desc": {
+          "en": "Gives your own AI agent a seat in the meeting: it joins Google Meet or Zoom, listens, and answers out loud in a real voice — the memory, skills, and tools stay on the agent you already use",
+          "ja": "自分の AI エージェントに会議の席を与える。Google Meet や Zoom に参加して聞き、実際の声で答える——記憶・スキル・道具はいつも使っているエージェントのまま",
+          "zh": "让你自己的 AI 智能体在会议中拥有一席：加入 Google Meet 或 Zoom，聆听并用真实语音开口回应——记忆、技能与工具仍留在你原本使用的智能体上",
+          "th": "ให้เอเจนต์ AI ของคุณมีที่นั่งในห้องประชุม เข้าร่วม Google Meet หรือ Zoom ฟังและตอบด้วยเสียงจริง — ความจำ ทักษะ และเครื่องมือยังอยู่กับเอเจนต์ที่คุณใช้อยู่แล้ว"
+        }
+      },
       "family-memory-architecture": {
         "name": "family-memory-architecture",
         "desc": {
@@ -422,6 +431,33 @@
       "owns": {
         "en": "proposal, governance, adoption records, growth interpretation",
         "ja": "提案・ガバナンス・採用記録・成長の解釈"
+      },
+      "footer": true
+    },
+    {
+      "id": "meetmate",
+      "name": "Meetmate",
+      "repo": "caty-ai/meetmate",
+      "status": "published",
+      "maturity": "product",
+      "tagline": {
+        "en": "Puts your own AI agent in the meeting — a real voice participant in Google Meet and Zoom",
+        "ja": "自分の AI エージェントを会議へ — Google Meet と Zoom に声で参加する",
+        "zh": "让你的 AI 智能体入席会议 — 在 Google Meet 与 Zoom 中以真实语音参与",
+        "th": "พาเอเจนต์ AI ของคุณเข้าประชุม — ผู้ร่วมประชุมด้วยเสียงจริงใน Google Meet และ Zoom"
+      },
+      "axis": {
+        "group": "vertical",
+        "foundation": false
+      },
+      "license": "MIT",
+      "class": {
+        "en": "runtime, standalone",
+        "ja": "runtime・単独利用可能"
+      },
+      "owns": {
+        "en": "meeting attendance and the agent's voice seat — audio in, speech out",
+        "ja": "会議への参加とエージェントの声の席 — 音声の入力と発話"
       },
       "footer": true
     },


### PR DESCRIPTION
Closes part of #94 (E1).

## Why

meetmate went public today, so the map can claim it as published without the claim running ahead of reality:

- repository: https://github.com/caty-ai/meetmate
- release: https://github.com/caty-ai/meetmate/releases/tag/v8.0.0 (signed tag)
- main: `2d721aa00562362dc54148440d9e33db595c7f02`
- history: 344 commits from 2026-02-27, 27 preceding tags

## What changed

| File | Change |
|---|---|
| `registry/modules.json` | meetmate entry in `modules` and `org_profile.modules`, placed at the end of the vertical group |
| `FOR-AGENTS.md` | tour row required by contract A-8 |
| `README.md` / `.ja` / `.zh` / `.th`, `docs/engineering.md` / `.ja`, `docs/readme-visual-system.md` | regenerated by `tools/render.py` — not hand-edited |

Diff is 9 files, 44 insertions, 0 deletions. `registry/modules.json` is a pure insertion: the file round-trips byte-identically through `json.dumps(..., ensure_ascii=False, indent=2)`, so nothing else in it was reformatted.

## Verification

```
make test                      -> exit 0
  10 modules, 10 tour rows, render --check up to date
python3 -B tools/check_registry.py   (network, anonymous)  -> exit 0
  reality check      : 0 of 11 skipped
  orphan check       : 0 of 1 skipped
  pin freshness      : 0 of 1 skipped
  ci existence       : 0 of 1 skipped
```

meetmate is verified against GitHub rather than assumed. The one `pin-freshness` note (self-growth-loop pinning caty-agent-harness@v0.6.0) is pre-existing, carries its documented `pin_reason`, and is untouched by this change.

`check_registry.py` initially failed with `tour: caty-ai/meetmate is published in the registry but missing from FOR-AGENTS.md §5`. That is the A-8 contract working as designed; the tour row was added rather than the check relaxed.

## Scope note — why the footer is not in this PR

E2 (family footer inside meetmate's READMEs) is deliberately separate. Registering a tenth module makes the generated footer table stale in **every** published sibling, not only meetmate. `family-links.yml` already anticipates exactly this and defers the remote footer contract check to `schedule`/`workflow_dispatch`, with the comment that running it per-push "would create publication-PR deadlock". So E1 lands first and the footers are re-rendered afterwards, ahead of the Monday reality run. The sibling re-render obligation is recorded on #94.

## Review

Not self-approving (L1-3). Sized S — mechanical registry insertion plus generated output, no boundary change.
