### PR TITLE
registry: enforce the family footer for persona-growth-loop (#75)

### DIFF
--- a/registry/modules.json
+++ b/registry/modules.json
@@ -362,7 +362,8 @@
       "owns": {
         "en": "minimised, idempotent proposal production",
         "ja": "最小化された冪等な提案の生成"
-      }
+      },
+      "footer": true
     },
     {
       "id": "x-collector",


### PR DESCRIPTION
Closes #75

## What this changes

One line: `"footer": true` on the `persona-growth-loop` row of `registry/modules.json`.

persona-growth-loop has been `status: published` with four-language taglines since its footer landed (pgl#9, PR pgl#23), but its row never gained the flag the other eight published siblings carry. The visible symptom is four `footer exists but is not enforced` errors on the weekly run. The less visible one matters more: `check_registry_footers()` does `continue` for a non-enforced module, so it **skips content comparison entirely** — any real footer drift in that repository has been going unchecked behind those four errors.

It was. The pgl footer carries the same stale context-kit row the other three siblings had, so flipping this flag alone does not turn the run green; it only changes the four errors from `footer exists but is not enforced` to `footer content does not match the registry`. The matching re-render is `caty-ai/persona-growth-loop#31`, and the two must land together.

All four cells, measured 2026-08-21 — not reasoned about:

| registry `footer` | pgl README | `check --require-reality` (pgl errors) |
| --- | --- | --- |
| absent | stale | 4 × `footer exists but is not enforced` |
| absent | re-rendered | 4 × `footer exists but is not enforced` |
| `true` | stale | 4 × `footer content does not match the registry` |
| `true` | re-rendered | **0** |

## Files touched, against the declaration (L0-6)

Declared in #75: `registry/modules.json` (only).

```
 registry/modules.json | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

Diff matches the declaration exactly — one declared file, no others.

## Done when — evidence

| Done when | Result |
| --- | --- |
| `footer: true` on the persona-growth-loop row | PASS |
| `make test` green | PASS — exit 0 (`selftest_check_registry`; `selftest_family_footer` 20/20; publication-gate selftest, 60 assertions; `selftest_check_evidence_warning`; `check_registry.py --offline`; `render.py --check` → *up to date*, i.e. the flag changes no generated content in this repository) |
| `family_footer.py lint` green | PASS — self-consistent |
| the weekly run stops reporting persona-growth-loop | PASS, measured pre-merge — see below |

**Pre-merge measurement, and why it needed building.** `check_registry_footers()` reads `raw.githubusercontent.com/<repo>/HEAD`, so it cannot see unmerged work; and the sibling footer check runs only on `schedule` / `workflow_dispatch`, never on `pull_request` (deliberate, `family-links.yml`, to avoid a publication-PR deadlock — `docs/family-footer-contract.md`). A registry PR can therefore go green here and still put the Monday run in the red, which is exactly what happened the last time modules moved.

So the real function was run with its `fetcher` argument swapped for one that serves the four repositories in this sweep from local checkouts and everything else live from GitHub:

```
served from local checkouts: 16 files
=== ERROR COUNT: 0 ===
```

down from 16 on today's unmodified mains. **Negative control:** with this flag reverted and the four re-renders kept, the same harness returns the 4 `footer exists but is not enforced` errors — so the zero is a real measurement, not a harness that always passes.

## Risk review and serialization

`registry/**` is a declared gate risk path in this repository, so this PR needs the owner's `risk-reviewed` label; I have not applied it. Review seats are recorded in a comment below.

**L2-4:** open PR #97 (`feat/registry-alpha-nightshift`, draft, `needs-risk-review`) also touches `registry/modules.json` → intersecting declared file sets, so these two are serial. This lane goes first while #97 is a draft; #97 rebases onto it.

Separately, #97 carries a measured hazard of the same class as the one this sweep is cleaning up — merging it adds a tenth row to every sibling's generated footer, which re-drifts all nine published repositories while its own PR CI stays green. Evidence is written up on #97; that lane, not this one, owns the fix.

## Sweep

One of five lanes for the same weekly failure: `caty-ai/x-collector#62`, `caty-ai/sitter#32`, `caty-ai/family-memory-architecture#51`, `caty-ai/persona-growth-loop#31`, and this PR.
