### PR TITLE
docs(registry): sitter tagline — restarts only within declared bounds

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -369,7 +369,7 @@ Family OS が広がっても、次の5つは変わりません。
 | 縦軸 | [X Collector](https://github.com/caty-ai/x-collector) | Xやウェブの素材を1日1回のダイジェストに — 人にもエージェントにも | 公開・MIT |
 | 縦軸 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録 | 公開・MIT |
 | 横軸・基盤 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 記憶バス — 家族が知っていることを共有する層 | 公開・MIT |
-| 横軸 | [Sitter](https://github.com/caty-ai/sitter) | 委譲したエージェント実行の見張り番 — 監視・証拠の記録・再起動 | 公開・MIT |
+| 横軸 | [Sitter](https://github.com/caty-ai/sitter) | 委譲したエージェント実行の見張り番 — 監視・証拠の記録・宣言した範囲内でのみ再起動 | 公開・MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Every module on this map, with its current state — generated from the same reg
 | Vertical | [X Collector](https://github.com/caty-ai/x-collector) | Turns X and the web into one daily digest — for people and agents | published, MIT |
 | Vertical | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | Lets an agent grow its own abilities — proposals, governance, adoption records | published, MIT |
 | Horizontal · foundation | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | The memory bus — how the family shares what it knows | published, MIT |
-| Horizontal | [Sitter](https://github.com/caty-ai/sitter) | Babysits delegated agent runs — watches, keeps evidence, restarts | published, MIT |
+| Horizontal | [Sitter](https://github.com/caty-ai/sitter) | Babysits delegated agent runs — watches, keeps evidence, restarts only within declared bounds | published, MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.th.md
+++ b/README.th.md
@@ -369,7 +369,7 @@ flowchart TB
 | แกนตั้ง | [X Collector](https://github.com/caty-ai/x-collector) | รวบรวมข้อมูลจาก X และเว็บเป็นสรุปวันละฉบับ — สำหรับคนและเอเจนต์ | เปิดแล้ว・MIT |
 | แกนตั้ง | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง — ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้ | เปิดแล้ว・MIT |
 | แกนนอน · รากฐาน | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้ | เปิดแล้ว・MIT |
-| แกนนอน | [Sitter](https://github.com/caty-ai/sitter) | พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ต | เปิดแล้ว・MIT |
+| แกนนอน | [Sitter](https://github.com/caty-ai/sitter) | พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ตเฉพาะในขอบเขตที่ประกาศไว้ | เปิดแล้ว・MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -369,7 +369,7 @@ Family OS 这边没有要做的事。不用安装，不用注册账号，也没�
 | 纵轴 | [X Collector](https://github.com/caty-ai/x-collector) | 把 X 与网络素材汇成每日一份摘要 — 给人也给智能体 | 已公开・MIT |
 | 纵轴 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | 让智能体自我成长的循环 — 提案、治理与采用记录 | 已公开・MIT |
 | 横轴・基座 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 记忆总线 — 家族共享所知的一层 | 已公开・MIT |
-| 横轴 | [Sitter](https://github.com/caty-ai/sitter) | 替你盯着委派出去的智能体 — 监视、留证、重启 | 已公开・MIT |
+| 横轴 | [Sitter](https://github.com/caty-ai/sitter) | 替你盯着委派出去的智能体 — 监视、留证、仅在声明范围内重启 | 已公开・MIT |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -562,10 +562,10 @@
       "status": "published",
       "maturity": "product",
       "tagline": {
-        "en": "Babysits delegated agent runs — watches, keeps evidence, restarts",
-        "ja": "委譲したエージェント実行の見張り番 — 監視・証拠の記録・再起動",
-        "zh": "替你盯着委派出去的智能体 — 监视、留证、重启",
-        "th": "พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ต"
+        "en": "Babysits delegated agent runs — watches, keeps evidence, restarts only within declared bounds",
+        "ja": "委譲したエージェント実行の見張り番 — 監視・証拠の記録・宣言した範囲内でのみ再起動",
+        "zh": "替你盯着委派出去的智能体 — 监视、留证、仅在声明范围内重启",
+        "th": "พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ตเฉพาะในขอบเขตที่ประกาศไว้"
       },
       "axis": {
         "group": "horizontal",


### PR DESCRIPTION
## Why
External review (2026-08-23) flagged that the sitter one-liner transcribed into every family footer — "Babysits delegated agent runs — watches, keeps evidence, restarts" — drops sitter's core promise: it never restarts outside declared bounds. The repo description and sitter's own README carry the bound; the most widely copied line did not. Owner-requested fix (Sho, 2026-08-23).

## What
- `registry/modules.json`: sitter `tagline` en/ja/zh/th → append "only within declared bounds" (each language). `desc`/`desc_short` untouched (already accurate — org profile block is unchanged, verified with `render-org`: all files `unchanged`).
- `README*.md` (4): regenerated `family-table` block via `tools/render.py` — sitter row only.

## Files touched (declared set = diff)
registry/modules.json, README.md, README.ja.md, README.zh.md, README.th.md — 5 files, +8/−8. No other hunks.

## Verification
- `tools/check_registry.py` → OK (pre-existing pin-freshness note only)
- `tools/selftest_check_registry.py` / `tools/selftest_family_footer.py` → OK
- `tools/render.py --check` clean after regen

## Rollout
Sibling sweep (9 published repos × declared READMEs) rendered with `family_footer.py render-all`; mechanical PRs follow, then `workflow_dispatch` of family-links so the content check goes green today (contract runbook / #107 pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)