### PR TITLE
repo-state core: deterministic stamp generator + status.json schema + reusable CI workflow (fos#127)

### DIFF
--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -1,0 +1,146 @@
+name: repository state
+
+# Caller contract: grant `permissions: contents: write` and serialize with
+# `concurrency: group: repo-state-${{ github.ref }}`. Example caller:
+#
+# name: repository state
+# on:
+#   push:
+#     branches: [main]
+#   release:
+#     types: [published]
+#   workflow_dispatch:
+#   pull_request:
+# permissions:
+#   contents: write
+# concurrency:
+#   group: repo-state-${{ github.ref }}
+#   cancel-in-progress: false
+# jobs:
+#   repo-state:
+#     uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.0
+#     with:
+#       generator_ref: v0.11.0
+
+on:
+  workflow_call:
+    inputs:
+      generator_ref:
+        description: Pinned family-os tag containing tools/repo-state-gen.sh
+        required: true
+        type: string
+
+jobs:
+  update:
+    name: update repository state
+    if: >-
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+       github.actor != 'github-actions[bot]' &&
+       !startsWith(github.event.head_commit.message, 'chore(repo-state):'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: check out default branch for release or dispatch
+        if: github.event_name != 'push'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: check out pushed commit
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: fetch pinned generator
+        env:
+          GENERATOR_REF: ${{ inputs.generator_ref }}
+        run: |
+          case "$GENERATOR_REF" in
+            ''|*[!A-Za-z0-9._-]*)
+              echo "invalid generator_ref; use a pinned tag" >&2
+              exit 1
+              ;;
+          esac
+          curl --fail --silent --show-error --location \
+            "https://raw.githubusercontent.com/caty-ai/family-os/$GENERATOR_REF/tools/repo-state-gen.sh" \
+            --output "$RUNNER_TEMP/repo-state-gen.sh"
+          chmod +x "$RUNNER_TEMP/repo-state-gen.sh"
+
+      - name: regenerate and push when changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_STATE_BRANCH: ${{ github.event.repository.default_branch }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -eu
+
+          generator="$RUNNER_TEMP/repo-state-gen.sh"
+          "$generator" --stamp-mode auto
+
+          if [ -z "$(git status --porcelain -- status.json 'README*.md' AGENTS.md FOR-AGENTS.md)" ]; then
+            echo "repo-state is already current; no commit"
+            exit 0
+          fi
+
+          agents_entry=$(jq -r '.agents_entry' status.json)
+          describes_commit=$(jq -r '.describes_commit' status.json)
+          short_sha=$(printf '%s' "$describes_commit" | cut -c1-7)
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -- status.json 'README*.md' "$agents_entry"
+          git commit -m "chore(repo-state): $short_sha"
+
+          if git push origin "HEAD:$TARGET_BRANCH"; then
+            exit 0
+          fi
+
+          echo "initial push rejected; rebasing once and regenerating" >&2
+          git reset --hard HEAD^
+          git pull --rebase origin "$TARGET_BRANCH"
+          "$generator" --stamp-mode auto
+          if [ -z "$(git status --porcelain -- status.json 'README*.md' AGENTS.md FOR-AGENTS.md)" ]; then
+            echo "repo-state was refreshed by the racing run; no retry commit"
+            exit 0
+          fi
+          agents_entry=$(jq -r '.agents_entry' status.json)
+          describes_commit=$(jq -r '.describes_commit' status.json)
+          short_sha=$(printf '%s' "$describes_commit" | cut -c1-7)
+          git add -- status.json 'README*.md' "$agents_entry"
+          git commit -m "chore(repo-state): $short_sha"
+          git push origin "HEAD:$TARGET_BRANCH"
+
+  check:
+    name: check repository state contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: fetch pinned generator
+        env:
+          GENERATOR_REF: ${{ inputs.generator_ref }}
+        run: |
+          case "$GENERATOR_REF" in
+            ''|*[!A-Za-z0-9._-]*)
+              echo "invalid generator_ref; use a pinned tag" >&2
+              exit 1
+              ;;
+          esac
+          curl --fail --silent --show-error --location \
+            "https://raw.githubusercontent.com/caty-ai/family-os/$GENERATOR_REF/tools/repo-state-gen.sh" \
+            --output "$RUNNER_TEMP/repo-state-gen.sh"
+          chmod +x "$RUNNER_TEMP/repo-state-gen.sh"
+
+      - name: check repository state contract
+        run: '"$RUNNER_TEMP/repo-state-gen.sh" --check'

--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -83,7 +83,18 @@ jobs:
           set -eu
 
           generator="$RUNNER_TEMP/repo-state-gen.sh"
-          "$generator" --stamp-mode auto
+          regenerate() {
+            case "${GITHUB_EVENT_NAME:-}" in
+              release|workflow_dispatch)
+                REPO_STATE_REFRESH_RELEASE=1 "$generator" --stamp-mode auto
+                ;;
+              *)
+                "$generator" --stamp-mode auto
+                ;;
+            esac
+          }
+
+          regenerate
 
           if [ -z "$(git status --porcelain -- status.json 'README*.md' AGENTS.md FOR-AGENTS.md)" ]; then
             echo "repo-state is already current; no commit"
@@ -106,7 +117,7 @@ jobs:
           echo "initial push rejected; rebasing once and regenerating" >&2
           git reset --hard HEAD^
           git pull --rebase origin "$TARGET_BRANCH"
-          "$generator" --stamp-mode auto
+          regenerate
           if [ -z "$(git status --porcelain -- status.json 'README*.md' AGENTS.md FOR-AGENTS.md)" ]; then
             echo "repo-state was refreshed by the racing run; no retry commit"
             exit 0

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Test entry point (family decision 4, issue #59). Wraps the existing
 # checks — the scripts themselves are canonical; do not add logic here.
 test:
+	bash tools/selftest_repo_state_gen.sh
 	python3 -B tools/selftest_check_registry.py
 	python3 -B tools/selftest_family_footer.py
 	python3 -B tools/check_publication_gate.py --selftest

--- a/docs/repo-state/DESIGN.md
+++ b/docs/repo-state/DESIGN.md
@@ -180,7 +180,7 @@ nobody later mistakes it for a bug.
 1. family-os: schema + generator + reusable workflow + spec page + readme-standard
    amendment + L0-5 exception PR (handbook) + parent issue.
 2. Child issues per repo. Every caller PR touches `.github/workflows/**` → risk gate
-   requires 翔さん's human label (verified: `review-labels.yml` risk_paths_gates) — batch
+   requires the repository owner's human label (verified: `review-labels.yml` risk_paths_gates) — batch
    all label clicks into one sitting [rev: GLM F8d].
 3. New-repo template gains caller + stamp stanza (D1 future-repos; backstop = registry
    orphan check, which already enforces org-wide accounting).

--- a/docs/repo-state/DESIGN.md
+++ b/docs/repo-state/DESIGN.md
@@ -1,0 +1,199 @@
+# DESIGN v0.2 — repo-state: version stamp + status.json + CI enforcement (caty-ai public repos)
+
+- Date: 2026-08-25
+- Author: Alpha (design writer). Implementation writer: Codex GPT-5.6 Sol (code_workflow default).
+- Status: v0.2 — incorporates all blocking findings from the L1-9 pre-implementation
+  3-seat heterogeneous review of v0.1 (Kimi K3 / Grok 4.6 / GLM 5.3, all fresh-context
+  read-only, all GO-WITH-CHANGES). Finding IDs below reference the seat reviews.
+- Owner decisions frozen (2026-08-25 clarify batch):
+  - D1: scope = ALL caty-ai public repos; CI-enforced so future repos/commits cannot forget
+  - D2: canon + parent issue in caty-ai/family-os
+  - D3: update mechanism = CI auto-update
+
+## 1. Problem (unchanged from v0.1)
+
+External AI reviewers/agents fetching our public repos through GitHub HTML pages receive
+CDN-cached content of mixed generations (4 generations of one page observed in one session,
+2026-08-25). README tails get truncated by tooling. Goal: any reader on any generation can
+(a) see which generation it is, (b) follow one pointer to a canonical small state file.
+Staleness DETECTION, not freshness proof. Non-goal: forcing GitHub to serve latest HTML.
+
+## 2. Components
+
+### 2.1 Stamp block — stamped-file set [rev: Grok F6, Kimi F5, GLM F4]
+
+The stamped set per repo is exactly:
+1. every `README*.md` at repo root (all four locales: `README.md`, `README.ja.md`,
+   `README.zh.md`, `README.th.md` — whichever exist), and
+2. the file named by `agents_entry` — `FOR-AGENTS.md` **or** `AGENTS.md`, whichever the
+   repo actually has (harness has `AGENTS.md`; the check resolves the name, never assumes).
+
+Block (idempotent, replace-between-markers), placed immediately after the readme-standard
+centered header `</div>` (or after the H1 where no header div exists), before the intro/TOC.
+In the agents file it goes after the H1 without displacing the existing "one-line route"
+convention line:
+
+```markdown
+<!-- repo-state:begin (generated; do not edit) -->
+<p align="center"><sub>generation: <code>48aa5ca</code> (2026-08-25T13:00Z) · verify: <a href="https://api.github.com/repos/caty-ai/caty-agent-harness/commits/main">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<!-- repo-state:end -->
+```
+
+- SHA-first; timestamp is ISO time, not bare date [rev: Grok F2 "date is a costume"].
+- The contract is the marker comments, not the rendered HTML (non-GitHub renderers may
+  strip HTML) [rev: Kimi F8].
+- readme-standard canon gets a one-line amendment blessing this position and the markers,
+  so canon-driven README rewrites don't strip them [rev: Kimi F8, GLM Q3].
+
+### 2.2 status.json (repo root, ≤ 2 KB) [rev: Grok F7/Q5, Kimi F7/Q5, GLM Q5]
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/caty-ai/family-os/main/docs/repo-state/status.schema.json",
+  "schema_version": 1,
+  "generator_version": "repo-state-gen v1",
+  "repo": "caty-ai/caty-agent-harness",
+  "stamp_mode": "auto",
+  "generated_at": "2026-08-25T13:00:00Z",
+  "describes_commit": "48aa5ca5ac773925bbb21c0839b55acc079740b3",
+  "describes_commit_date": "2026-08-25T12:41:07Z",
+  "branch": "main",
+  "latest_tag": "v0.13.0",
+  "latest_release_url": "https://github.com/caty-ai/caty-agent-harness/releases/tag/v0.13.0",
+  "agents_entry": "AGENTS.md",
+  "canonical_api": "https://api.github.com/repos/caty-ai/caty-agent-harness/commits/main",
+  "canonical_raw": "https://raw.githubusercontent.com/caty-ai/caty-agent-harness/48aa5ca5ac773925bbb21c0839b55acc079740b3/status.json",
+  "freshness_contract": "See reader protocol in §2.3; SHA comparison only. A date may only ever trigger distrust, never trust."
+}
+```
+
+Changes vs v0.1: `canonical_api` added (CDN-free); `canonical_raw` now points at
+raw@describes_commit (immutable), not raw@branch; `generator_version`, `stamp_mode`,
+`describes_commit_date`, `$schema` added. `generated_at` is set to the committer date of
+`describes_commit`, NOT wall clock — regeneration is fully deterministic, so an unchanged
+content state produces a byte-identical file [rev: GLM F2].
+
+### 2.3 Reader protocol — SHA-based, never date-based [rev: Kimi F1 + Grok F2 + GLM F3/F7 — 3-seat convergent CRITICAL]
+
+Written into the spec page, the FOR-AGENTS/AGENTS stanza, and `freshness_contract`:
+
+1. Resolve true HEAD once via `https://api.github.com/repos/{owner}/{repo}/commits/{branch}`
+   (or `git ls-remote`) — the API does not ride the page CDN.
+2. A page is CURRENT ⇔ its stamp SHA == HEAD, or HEAD is a stamp commit and
+   stamp SHA == HEAD^ [rev: GLM F7 — prevents false-stale desensitization].
+3. On ANY mismatch (older or newer): re-fetch everything at `raw@<sha>` pinned to the API
+   HEAD (or clone at that SHA). raw@branch fetches are advisory only — every file at a
+   branch ref rides an independent cache, so a fresh status.json vouches for nothing else
+   fetched at a branch ref [rev: GLM F3].
+4. Dates/`generated_at` may only ever trigger DIStrust, never trust. Two dates from two
+   caches are not comparable evidence [rev: Kimi F1 scenario].
+5. For commissioned reviews, hand reviewers SHA-pinned raw URLs / clone-at-SHA up front
+   (§2.6) — the stamps are the safety net for uncommissioned readers, not the primary path.
+
+## 3. CI mechanism
+
+### 3.1 Reusable workflow + caller [rev: Grok F1, Kimi F2/F6, GLM F2/F5/F8a]
+
+- `caty-ai/family-os/.github/workflows/repo-state.yml` (workflow_call) + generator script
+  `tools/repo-state-gen.sh` vendored in family-os, consumed by callers at a pinned tag.
+- Caller (~12 lines) in each repo: triggers `push: branches [main]`,
+  `release: types [published]`, `workflow_dispatch`, `pull_request` (check job only).
+  Caller MUST set `permissions: contents: write` — reusable workflows cannot elevate
+  the token themselves [rev: GLM F8a]. `concurrency: group: repo-state-${{ github.ref }}`
+  serializes racing runs [rev: GLM F2, Grok F7].
+- Loop/skip guards, event-scoped [rev: Grok F1 CRITICAL, GLM F5 — v0.1's guard both blocked
+  the release path and failed to stop loops]:
+  - `push` events only: skip when `github.actor == 'github-actions[bot]'` (primary) or the
+    head commit message starts with `chore(repo-state):` (backup) [rev: Kimi F6, GLM F2].
+  - `release` / `workflow_dispatch` / `pull_request` events: never skipped. Release runs
+    check out **main HEAD** (GITHUB_SHA for release events is the last commit on the
+    default branch — confirmed against GitHub docs by two seats) and refresh release
+    fields; they do not stamp the tag SHA [rev: Kimi F2 MAJOR].
+  - Determinism is the real loop-stopper: regeneration of an unchanged content state is
+    byte-identical (§2.2) → no diff → no commit, on every trigger and every token type
+    [rev: Grok F1 — prefix guard alone is lethal with PAT/App tokens].
+- `describes_commit` := nearest non-stamp ancestor of the checked-out HEAD (walk past
+  consecutive `chore(repo-state):` commits) [rev: Grok F1, GLM F6a].
+- Stamp commits: message `chore(repo-state): <short-sha>`; author/committer =
+  `github-actions[bot]` (standard noreply identity). Push failure fails the job loudly
+  (no `|| true`); one `pull --rebase` retry [rev: Grok F7].
+
+### 3.2 Delivery to main — canon compliance [rev: Grok F4, Kimi F4 MAJOR]
+
+Handbook L0-5 says main is merge-only. Resolution, in order of preference:
+1. **Single mode (default): bot push under a recorded, scoped canon exception** — text to
+   land in `docs/03-git-protocol.md` via the normal handbook PR path:
+   "`github-actions[bot]` may push `chore(repo-state):` stamp commits to main; all other
+   direct pushes remain forbidden." Branch protection gets an allowance for the bot where
+   protection exists. The exception is part of this design's Done-when, not an afterthought.
+2. **verify-only mode (documented exception only, per repo, registry-recorded)**: where an
+   allowance is impossible. The make target stamps the current BASE-branch HEAD (post-merge
+   it describes HEAD^), never the PR-branch head — squash-merge would otherwise strand an
+   unreachable SHA and produce weekly false alarms [rev: GLM F6b]. `stamp_mode` in
+   status.json makes the mode machine-visible; audit rules are per-mode [rev: GLM Q4].
+   Verify-only repos are stale-by-construction at every HEAD (safe direction); the spec
+   says so explicitly [rev: Kimi Q4]. No third mode exists.
+
+### 3.3 Check job (PR + push) vs weekly audit — division of labor [rev: Grok F3 vs GLM F1, synthesized]
+
+- **PR check (`pull_request`, required status via org ruleset)**: presence + schema-valid +
+  markers present in the full stamped set (§2.1) + cross-file consistency (stamp SHA/time
+  in every stamped file == status.json). NO freshness diff — content PRs legitimately lack
+  regenerated stamps [rev: GLM F1 tail]. Fork PRs get exactly this read-only job.
+- **Weekly audit (family-os, extends the existing `family-links` Sunday run)**: for every
+  org public repo (universe = the registry's orphan-checked set, `check_registry.py`
+  `--require-reality`, fail-closed [rev: Grok F5, GLM F8c]):
+  a. status.json exists, schema-valid;
+  b. health invariant by IDENTITY, not position [rev: GLM F1 CRITICAL — v0.1's
+     "HEAD or HEAD^" blessed a dead stamper forever]: auto-mode healthy ⇔ HEAD is a bot
+     stamp commit ∧ describes_commit == nearest non-stamp ancestor; HEAD being a content
+     commit is drift unless it clears within the next run (transient window);
+     verify-only-mode healthy ⇔ per-mode rule (§3.2.2);
+  c. regenerate-and-diff on main HEAD: run the generator, tree-diff outside stamp-managed
+     regions must be empty [rev: Grok F4 "honest invariant", GLM F1];
+  d. latest repo-state caller run conclusion per repo via API — a disabled/unparseable/
+     failing caller is drift even when files look right [rev: Kimi F3b];
+  e. results land as dated lines in the existing weekly report issue (visible heartbeat).
+- **Dead-man's switch** [rev: Kimi F3 + Grok F5 + GLM F8e — convergent MAJOR]: the audit's
+  ABSENCE must itself alarm. The existing FMA schedule-liveness probe (outside GitHub cron)
+  watches the weekly report issue's freshness; report missing > 8 days ⇒ alert. GitHub's
+  60-day auto-disable of scheduled workflows is the named enemy.
+
+### 3.4 Cost statement [rev: Kimi F6, GLM F8b — owner accepts with eyes open]
+
+Every content push to main yields one bot stamp commit (history ~2× commit count on quiet
+repos; push-CI runs ~2× since stamp commits re-trigger on-push workflows — mitigate with a
+`paths-ignore` on heavy workflows where wanted). This is the price of D3; recorded here so
+nobody later mistakes it for a bug.
+
+## 4. Rollout
+
+1. family-os: schema + generator + reusable workflow + spec page + readme-standard
+   amendment + L0-5 exception PR (handbook) + parent issue.
+2. Child issues per repo. Every caller PR touches `.github/workflows/**` → risk gate
+   requires 翔さん's human label (verified: `review-labels.yml` risk_paths_gates) — batch
+   all label clicks into one sitting [rev: GLM F8d].
+3. New-repo template gains caller + stamp stanza (D1 future-repos; backstop = registry
+   orphan check, which already enforces org-wide accounting).
+4. harness: release-sync composes with the `release: published` trigger; no manual
+   `gh release create` there (known).
+
+## 5. Future work (recorded, not in scope)
+
+- Org-level `index.json` in family-os (all repos' HEAD SHAs, written by the weekly audit)
+  as a SECOND channel — all three seats independently evaluated it as a replacement and
+  rejected it (a central file can't mark which generation a cached page is), but two
+  recommended it as a complement [Grok Q6, GLM Q6, Kimi Q6].
+- caty.talk no-cache mirror and llms.txt: deferred (owner decision 2026-08-25).
+
+## 6. Review record
+
+- v0.1 reviewed 2026-08-25 by 3 heterogeneous fresh-context read-only seats
+  (writer=Alpha/Anthropic; opus-5 excluded as same-family, substituted grok-4.6 per
+  loom-seats): Kimi K3 GO-WITH-CHANGES · Grok 4.6 GO-WITH-CHANGES · GLM 5.3
+  GO-WITH-CHANGES. All blocking findings and all flip conditions are incorporated above;
+  full seat outputs archived with the parent issue.
+- Convergent findings (adopted as confirmed): SHA-not-date reader protocol (3 seats);
+  4-locale stamp set (3 seats); audit dead-man's switch (3 seats); event-scoped loop
+  guards + release-path unblocking (Grok+GLM); L0-5 conflict (Grok+Kimi); identity-based
+  health invariant (Grok+GLM).

--- a/docs/repo-state/DESIGN.md
+++ b/docs/repo-state/DESIGN.md
@@ -35,7 +35,7 @@ convention line:
 
 ```markdown
 <!-- repo-state:begin (generated; do not edit) -->
-<p align="center"><sub>generation: <code>48aa5ca</code> (2026-08-25T13:00Z) · verify: <a href="https://api.github.com/repos/caty-ai/caty-agent-harness/commits/main">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<p align="center"><sub>generation: <code>48aa5ca</code> (2026-08-25T13:00:00Z) · verify: <a href="https://api.github.com/repos/caty-ai/caty-agent-harness/commits/main">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
 <!-- repo-state:end -->
 ```
 
@@ -63,15 +63,16 @@ convention line:
   "agents_entry": "AGENTS.md",
   "canonical_api": "https://api.github.com/repos/caty-ai/caty-agent-harness/commits/main",
   "canonical_raw": "https://raw.githubusercontent.com/caty-ai/caty-agent-harness/48aa5ca5ac773925bbb21c0839b55acc079740b3/status.json",
-  "freshness_contract": "See reader protocol in §2.3; SHA comparison only. A date may only ever trigger distrust, never trust."
+  "freshness_contract": "SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'."
 }
 ```
 
 Changes vs v0.1: `canonical_api` added (CDN-free); `canonical_raw` now points at
 raw@describes_commit (immutable), not raw@branch; `generator_version`, `stamp_mode`,
 `describes_commit_date`, `$schema` added. `generated_at` is set to the committer date of
-`describes_commit`, NOT wall clock — regeneration is fully deterministic, so an unchanged
-content state produces a byte-identical file [rev: GLM F2].
+`describes_commit`, NOT wall clock. Ordinary runs carry forward the existing release
+fields, so regeneration of an unchanged content state without explicit release refresh is
+fully deterministic and produces a byte-identical file [rev: GLM F2].
 
 ### 2.3 Reader protocol — SHA-based, never date-based [rev: Kimi F1 + Grok F2 + GLM F3/F7 — 3-seat convergent CRITICAL]
 
@@ -87,8 +88,9 @@ Written into the spec page, the FOR-AGENTS/AGENTS stanza, and `freshness_contrac
    fetched at a branch ref [rev: GLM F3].
 4. Dates/`generated_at` may only ever trigger DIStrust, never trust. Two dates from two
    caches are not comparable evidence [rev: Kimi F1 scenario].
-5. For commissioned reviews, hand reviewers SHA-pinned raw URLs / clone-at-SHA up front
-   (§2.6) — the stamps are the safety net for uncommissioned readers, not the primary path.
+5. For commissioned reviews, hand reviewers SHA-pinned raw URLs / clone-at-SHA up front;
+   see `docs/repo-state/spec.md`, handover paragraph following Reader protocol. The stamps
+   are the safety net for uncommissioned readers, not the primary path.
 
 ## 3. CI mechanism
 
@@ -105,13 +107,20 @@ Written into the spec page, the FOR-AGENTS/AGENTS stanza, and `freshness_contrac
   the release path and failed to stop loops]:
   - `push` events only: skip when `github.actor == 'github-actions[bot]'` (primary) or the
     head commit message starts with `chore(repo-state):` (backup) [rev: Kimi F6, GLM F2].
-  - `release` / `workflow_dispatch` / `pull_request` events: never skipped. Release runs
-    check out **main HEAD** (GITHUB_SHA for release events is the last commit on the
-    default branch — confirmed against GitHub docs by two seats) and refresh release
-    fields; they do not stamp the tag SHA [rev: Kimi F2 MAJOR].
-  - Determinism is the real loop-stopper: regeneration of an unchanged content state is
-    byte-identical (§2.2) → no diff → no commit, on every trigger and every token type
-    [rev: Grok F1 — prefix guard alone is lethal with PAT/App tokens].
+    Push regeneration preserves the existing `latest_tag` / `latest_release_url` fields and
+    does not probe GitHub releases or `git describe`.
+  - `release` / `workflow_dispatch` events: never skipped. Release and
+    manual-dispatch runs check out **main HEAD** (GITHUB_SHA for release events is the last
+    commit on the default branch — confirmed against GitHub docs by two seats) and refresh
+    release fields by querying `gh api repos/{owner}/{repo}/releases/latest`; explicit 404
+    maps both fields to `null`, while any other transport or HTTP failure is fatal. These
+    runs do not stamp the tag SHA [rev: Kimi F2 MAJOR].
+  - Determinism is the real loop-stopper for ordinary push regeneration: when content and
+    carried-forward release metadata are unchanged, output is byte-identical (§2.2) → no
+    diff → no commit, regardless of token type [rev: Grok F1 — prefix guard alone is lethal
+    with PAT/App tokens]. `release` / `workflow_dispatch` are explicit metadata refresh
+    points; they diff only when content or refreshed metadata changes, and they fail
+    instead of writing partial state when refresh errors occur.
 - `describes_commit` := nearest non-stamp ancestor of the checked-out HEAD (walk past
   consecutive `chore(repo-state):` commits) [rev: Grok F1, GLM F6a].
 - Stamp commits: message `chore(repo-state): <short-sha>`; author/committer =
@@ -134,7 +143,7 @@ Handbook L0-5 says main is merge-only. Resolution, in order of preference:
    Verify-only repos are stale-by-construction at every HEAD (safe direction); the spec
    says so explicitly [rev: Kimi Q4]. No third mode exists.
 
-### 3.3 Check job (PR + push) vs weekly audit — division of labor [rev: Grok F3 vs GLM F1, synthesized]
+### 3.3 Check job (PR) vs weekly audit — division of labor [rev: Grok F3 vs GLM F1, synthesized]
 
 - **PR check (`pull_request`, required status via org ruleset)**: presence + schema-valid +
   markers present in the full stamped set (§2.1) + cross-file consistency (stamp SHA/time
@@ -197,3 +206,13 @@ nobody later mistakes it for a bug.
   4-locale stamp set (3 seats); audit dead-man's switch (3 seats); event-scoped loop
   guards + release-path unblocking (Grok+GLM); L0-5 conflict (Grok+Kimi); identity-based
   health invariant (Grok+GLM).
+
+## v0.2.1 amendments (2026-08-25 merge review)
+
+- R1: Ordinary generation carries forward existing `latest_tag` / `latest_release_url`
+  values; only explicit release refresh (`release`, `workflow_dispatch`, or
+  `--refresh-release`) queries GitHub, with explicit 404 mapping to `null`.
+- R2: `freshness_contract` now uses the exact required literal, and the handover citation
+  points to `docs/repo-state/spec.md`, handover paragraph following Reader protocol.
+- R3: Repo-state self-tests were hardened for ambiguity, missing anchors, `--check`
+  marker corruption, PATH-without-`gh`, and deterministic timestamp coverage.

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -1,0 +1,129 @@
+# Repository state protocol
+
+This document is the normative contract for repository state stamps. Agents use the
+reader protocol to decide which bytes to trust. Maintainers use the generator and CI
+mechanism to keep the contract consistent. The frozen design record is
+[`DESIGN.md`](./DESIGN.md).
+
+## 1. Stamp block and stamped-file set
+
+The stamped-file set is exactly:
+
+1. every existing `README*.md` at the repository root, including every locale; and
+2. the file named by `agents_entry`: either `FOR-AGENTS.md` or `AGENTS.md`, according to
+   which file the repository has.
+
+Each stamped file contains exactly one block with these marker comments:
+
+```markdown
+<!-- repo-state:begin (generated; do not edit) -->
+<p align="center"><sub>generation: <code>48aa5ca</code> (2026-08-25T13:00:00Z) · verify: <a href="https://api.github.com/repos/caty-ai/caty-agent-harness/commits/main">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<!-- repo-state:end -->
+```
+
+The marker comments, not rendered HTML, are the contract. The SHA is the first seven
+characters of `describes_commit`, and the timestamp is `generated_at` in ISO-8601 UTC.
+The API link is `canonical_api`.
+
+In a README, the block is immediately after the readme-standard centered header's
+closing `</div>`, or immediately after the H1 when there is no centered header. In the
+agents entry it is immediately after the H1; existing routing text remains intact.
+Generation replaces the region between valid markers and never appends a second region.
+A missing half, reversed pair, or duplicate marker is a hard error.
+
+## 2. `status.json`
+
+`status.json` is a UTF-8 JSON object at the repository root and is no larger than 2 KiB.
+Its schema is [`status.schema.json`](./status.schema.json). Field semantics are:
+
+| Field | Semantics |
+| --- | --- |
+| `$schema` | Canonical raw URL of the family-os status schema. |
+| `schema_version` | Integer protocol version; currently `1`. |
+| `generator_version` | Generator identity; currently `repo-state-gen v1`. |
+| `repo` | GitHub `owner/repository` slug. |
+| `stamp_mode` | Exactly `auto` or `verify-only`. No third mode exists. |
+| `generated_at` | Committer date of `describes_commit`, normalized to ISO-8601 UTC. It is never wall-clock time. |
+| `describes_commit` | Full lowercase 40-character SHA of the nearest ancestor whose commit message does not start with `chore(repo-state):`. |
+| `describes_commit_date` | Committer date of `describes_commit`, in ISO-8601 UTC. |
+| `branch` | Branch whose API HEAD is the comparison target, normally the default branch. |
+| `latest_tag` | Latest detected tag. It may be omitted or `null` when no tag is available. |
+| `latest_release_url` | Latest detected GitHub release URL. It may be omitted or `null` when no release is available or GitHub cannot be reached. |
+| `agents_entry` | The stamped agent entry file, exactly `FOR-AGENTS.md` or `AGENTS.md`. |
+| `canonical_api` | CDN-independent GitHub commits API URL for `repo` and `branch`. |
+| `canonical_raw` | Immutable raw URL for `status.json` at `describes_commit`. |
+| `freshness_contract` | A reminder that only the SHA protocol below can establish currentness. |
+
+Because both time fields derive from the described commit, regenerating an unchanged
+content state with unchanged release metadata produces byte-identical output.
+
+## 3. Reader protocol — SHA-based, never date-based
+
+1. Resolve true HEAD once via `https://api.github.com/repos/{owner}/{repo}/commits/{branch}`
+   (or `git ls-remote`) — the API does not ride the page CDN.
+2. A page is CURRENT ⇔ its stamp SHA == HEAD, or HEAD is a stamp commit and
+   stamp SHA == HEAD^ [rev: GLM F7 — prevents false-stale desensitization].
+3. On ANY mismatch (older or newer): re-fetch everything at `raw@<sha>` pinned to the API
+   HEAD (or clone at that SHA). raw@branch fetches are advisory only — every file at a
+   branch ref rides an independent cache, so a fresh status.json vouches for nothing else
+   fetched at a branch ref [rev: GLM F3].
+4. Dates/`generated_at` may only ever trigger DIStrust, never trust. Two dates from two
+   caches are not comparable evidence [rev: Kimi F1 scenario].
+5. For commissioned reviews, hand reviewers SHA-pinned raw URLs / clone-at-SHA up front
+   (§2.6) — the stamps are the safety net for uncommissioned readers, not the primary path.
+
+The review handover mechanism is therefore explicit: resolve one commit SHA first, then
+hand every reviewer raw URLs pinned to that SHA, or a clone checked out at that SHA. Do
+not hand reviewers branch-pinned raw URLs and do not use dates as evidence of freshness.
+
+## 4. CI semantics
+
+The reusable workflow has two jobs. `update` runs for default-branch pushes, published
+releases, and manual dispatches. Push events alone are skipped when the actor is
+`github-actions[bot]` or the head commit message begins `chore(repo-state):`. Release and
+manual events are never skipped. Release runs check out the default branch HEAD, not the
+release tag, so publishing a release refreshes release metadata without stamping the tag
+SHA.
+
+An update regenerates deterministic output and exits without a commit when the managed
+files have no diff. Otherwise it commits as `github-actions[bot]` with message
+`chore(repo-state): <short-sha>` and pushes. A rejected push gets one `pull --rebase`, a
+fresh regeneration, and one retry; a second failure fails the job. Caller workflows must
+grant `contents: write` and serialize runs with
+`concurrency: group: repo-state-${{ github.ref }}`.
+
+Automatic mode requires the recorded, scoped canon exception that allows
+`github-actions[bot]` to push only `chore(repo-state):` commits to the default branch;
+all other direct pushes remain forbidden. Branch protection must grant that bot the
+corresponding allowance where protection exists.
+
+The `check` job runs for pull requests and invokes only `repo-state-gen.sh --check`. It
+requires a schema-valid `status.json`, a valid marker block in the entire stamped-file
+set, and stamp SHA/time consistency with `status.json`. It deliberately performs no
+freshness comparison or regeneration diff: a content pull request legitimately has not
+yet received its post-merge automatic stamp.
+
+The separate family-os weekly audit covers every orphan-checked public repository and
+fails closed when reality cannot be enumerated. It verifies schema presence, applies the
+mode-specific health invariant by commit identity, regenerates and diffs the managed
+state, checks the latest caller-run conclusion, and appends dated results to the weekly
+report issue. An external schedule-liveness probe treats a report older than eight days
+as an alert, including GitHub's scheduled-workflow auto-disable failure mode.
+
+For `auto`, audit health means HEAD is a bot stamp commit and `describes_commit` is its
+nearest non-stamp ancestor; position alone is insufficient. The automatic mechanism
+adds roughly one stamp commit and one extra push-triggered CI run per content push.
+
+## 5. Verify-only mode
+
+`verify-only` is a documented, per-repository, registry-recorded exception for a
+repository where the bot cannot receive a scoped direct-push allowance. Its maintainer
+target runs the generator against the current base-branch HEAD, not the pull-request
+branch. After the content change merges, that stamp describes `HEAD^`; this avoids
+recording an unreachable pull-request SHA after a squash merge.
+
+Verify-only repositories are stale by construction at every post-merge HEAD. This is the
+safe direction: readers detect a mismatch and pin their fetches to the API HEAD. CI still
+checks presence, schema, the full stamped-file set, and cross-file consistency, while the
+registry audit applies its separate verify-only health rule. Select the mode with
+`repo-state-gen.sh --stamp-mode verify-only`; automatic repositories use `auto`.

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -47,15 +47,15 @@ Its schema is [`status.schema.json`](./status.schema.json). Field semantics are:
 | `describes_commit` | Full lowercase 40-character SHA of the nearest ancestor whose commit message does not start with `chore(repo-state):`. |
 | `describes_commit_date` | Committer date of `describes_commit`, in ISO-8601 UTC. |
 | `branch` | Branch whose API HEAD is the comparison target, normally the default branch. |
-| `latest_tag` | Latest detected tag. It may be omitted or `null` when no tag is available. |
-| `latest_release_url` | Latest detected GitHub release URL. It may be omitted or `null` when no release is available or GitHub cannot be reached. |
+| `latest_tag` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, and it is refreshed from GitHub only during an explicit release refresh. |
+| `latest_release_url` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, maps to `null` on an explicit GitHub 404 during release refresh, and any other refresh failure is fatal. |
 | `agents_entry` | The stamped agent entry file, exactly `FOR-AGENTS.md` or `AGENTS.md`. |
 | `canonical_api` | CDN-independent GitHub commits API URL for `repo` and `branch`. |
 | `canonical_raw` | Immutable raw URL for `status.json` at `describes_commit`. |
-| `freshness_contract` | A reminder that only the SHA protocol below can establish currentness. |
+| `freshness_contract` | Exactly `SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'.` |
 
 Because both time fields derive from the described commit, regenerating an unchanged
-content state with unchanged release metadata produces byte-identical output.
+content state without `--refresh-release` produces byte-identical output.
 
 ## 3. Reader protocol — SHA-based, never date-based
 
@@ -69,8 +69,9 @@ content state with unchanged release metadata produces byte-identical output.
    fetched at a branch ref [rev: GLM F3].
 4. Dates/`generated_at` may only ever trigger DIStrust, never trust. Two dates from two
    caches are not comparable evidence [rev: Kimi F1 scenario].
-5. For commissioned reviews, hand reviewers SHA-pinned raw URLs / clone-at-SHA up front
-   (§2.6) — the stamps are the safety net for uncommissioned readers, not the primary path.
+5. For commissioned reviews, hand reviewers SHA-pinned raw URLs / clone-at-SHA up front;
+   see the handover paragraph immediately below. The stamps are the safety net for
+   uncommissioned readers, not the primary path.
 
 The review handover mechanism is therefore explicit: resolve one commit SHA first, then
 hand every reviewer raw URLs pinned to that SHA, or a clone checked out at that SHA. Do
@@ -81,9 +82,12 @@ not hand reviewers branch-pinned raw URLs and do not use dates as evidence of fr
 The reusable workflow has two jobs. `update` runs for default-branch pushes, published
 releases, and manual dispatches. Push events alone are skipped when the actor is
 `github-actions[bot]` or the head commit message begins `chore(repo-state):`. Release and
-manual events are never skipped. Release runs check out the default branch HEAD, not the
-release tag, so publishing a release refreshes release metadata without stamping the tag
-SHA.
+manual events are never skipped. Push runs preserve the existing release fields and do
+not query GitHub releases. Release and manual-dispatch runs check out the default branch
+HEAD, not the release tag, and they refresh release metadata by running
+`repo-state-gen.sh --stamp-mode auto --refresh-release`. An explicit GitHub 404 maps the
+release fields to `null`; any other refresh failure fails the run without writing a
+partial update.
 
 An update regenerates deterministic output and exits without a commit when the managed
 files have no diff. Otherwise it commits as `github-actions[bot]` with message

--- a/docs/repo-state/status.schema.json
+++ b/docs/repo-state/status.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/caty-ai/family-os/main/docs/repo-state/status.schema.json",
+  "title": "caty-ai repository state",
+  "description": "Machine-readable state referenced by repository generation stamps.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "generator_version",
+    "repo",
+    "stamp_mode",
+    "generated_at",
+    "describes_commit",
+    "describes_commit_date",
+    "branch",
+    "agents_entry",
+    "canonical_api",
+    "canonical_raw",
+    "freshness_contract"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/caty-ai/family-os/main/docs/repo-state/status.schema.json"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "generator_version": {
+      "const": "repo-state-gen v1"
+    },
+    "repo": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+    },
+    "stamp_mode": {
+      "type": "string",
+      "enum": ["auto", "verify-only"]
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "describes_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "describes_commit_date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "branch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "latest_tag": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "latest_release_url": {
+      "type": ["string", "null"],
+      "format": "uri"
+    },
+    "agents_entry": {
+      "type": "string",
+      "enum": ["FOR-AGENTS.md", "AGENTS.md"]
+    },
+    "canonical_api": {
+      "type": "string",
+      "format": "uri"
+    },
+    "canonical_raw": {
+      "type": "string",
+      "format": "uri"
+    },
+    "freshness_contract": {
+      "const": "See reader protocol in §2.3; SHA comparison only. A date may only ever trigger distrust, never trust."
+    }
+  }
+}

--- a/docs/repo-state/status.schema.json
+++ b/docs/repo-state/status.schema.json
@@ -75,7 +75,7 @@
       "format": "uri"
     },
     "freshness_contract": {
-      "const": "See reader protocol in §2.3; SHA comparison only. A date may only ever trigger distrust, never trust."
+      "const": "SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'."
     }
   }
 }

--- a/tools/repo-state-gen.sh
+++ b/tools/repo-state-gen.sh
@@ -1,0 +1,428 @@
+#!/bin/sh
+
+set -eu
+
+PROGRAM=${0##*/}
+SCHEMA_URL=https://raw.githubusercontent.com/caty-ai/family-os/main/docs/repo-state/status.schema.json
+GENERATOR_VERSION='repo-state-gen v1'
+FRESHNESS_CONTRACT='See reader protocol in §2.3; SHA comparison only. A date may only ever trigger distrust, never trust.'
+BEGIN_MARKER='<!-- repo-state:begin (generated; do not edit) -->'
+END_MARKER='<!-- repo-state:end -->'
+
+fail() {
+    printf '%s: error: %s\n' "$PROGRAM" "$*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<EOF
+usage: $PROGRAM [--check] [--stamp-mode auto|verify-only]
+EOF
+    exit 2
+}
+
+check_only=false
+stamp_mode=${REPO_STATE_STAMP_MODE:-auto}
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        --check)
+            check_only=true
+            ;;
+        --stamp-mode)
+            [ "$#" -ge 2 ] || usage
+            stamp_mode=$2
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+case $stamp_mode in
+    auto|verify-only) ;;
+    *) fail "stamp mode must be auto or verify-only" ;;
+esac
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || fail "not inside a git repository"
+cd "$repo_root"
+
+tmp_root=$(mktemp -d "${TMPDIR:-/tmp}/repo-state-gen.XXXXXX") || fail "could not create temporary directory"
+trap 'rm -rf "$tmp_root"' 0 HUP INT TERM
+
+resolve_agents_entry() {
+    if [ -f FOR-AGENTS.md ] && [ -f AGENTS.md ]; then
+        fail "both FOR-AGENTS.md and AGENTS.md exist; agents_entry is ambiguous"
+    elif [ -f FOR-AGENTS.md ]; then
+        printf '%s\n' FOR-AGENTS.md
+    elif [ -f AGENTS.md ]; then
+        printf '%s\n' AGENTS.md
+    else
+        fail "neither FOR-AGENTS.md nor AGENTS.md exists"
+    fi
+}
+
+agents_entry=$(resolve_agents_entry)
+for readme_file in README*.md; do
+    [ -f "$readme_file" ] || continue
+    printf '%s\n' "$readme_file"
+done | LC_ALL=C sort > "$tmp_root/readmes"
+[ -s "$tmp_root/readmes" ] || fail "no root README*.md files found"
+cp "$tmp_root/readmes" "$tmp_root/targets"
+printf '%s\n' "$agents_entry" >> "$tmp_root/targets"
+
+marker_state() {
+    awk '
+        index($0, "<!-- repo-state:begin") {
+            begins++
+            if (!first_begin) first_begin = NR
+        }
+        index($0, "<!-- repo-state:end") {
+            ends++
+            if (!first_end) first_end = NR
+        }
+        END {
+            if (begins == 0 && ends == 0) {
+                print "absent"
+                exit 0
+            }
+            if (begins == 1 && ends == 1 && first_begin < first_end) {
+                print "present"
+                exit 0
+            }
+            exit 1
+        }
+    ' "$1"
+}
+
+centered_div_anchor_exists() {
+    awk '
+        {
+            lower = tolower($0)
+            if (index(lower, "<div") &&
+                (index(lower, "align=\"center\"") || index(lower, "align='\''center'\''"))) {
+                centered = 1
+            }
+            if (centered && index(lower, "</div>")) {
+                closed = 1
+                exit
+            }
+        }
+        END { exit !closed }
+    ' "$1"
+}
+
+h1_anchor_exists() {
+    awk '/^#[[:space:]]+[^#]/ { found = 1; exit } END { exit !found }' "$1"
+}
+
+while IFS= read -r file; do
+    [ -f "$file" ] || fail "stamped file is missing: $file"
+    if ! state=$(marker_state "$file"); then
+        fail "malformed repo-state markers in $file"
+    fi
+    if [ "$check_only" = false ] && [ "$state" = absent ]; then
+        if [ "$file" = "$agents_entry" ]; then
+            h1_anchor_exists "$file" || fail "cannot insert stamp in $file: H1 not found"
+        elif ! centered_div_anchor_exists "$file" && ! h1_anchor_exists "$file"; then
+            fail "cannot insert stamp in $file: centered header and H1 not found"
+        fi
+    fi
+done < "$tmp_root/targets"
+
+make_block() {
+    block_short_sha=$1
+    block_time=$2
+    block_api=$3
+    cat > "$4" <<EOF
+$BEGIN_MARKER
+<p align="center"><sub>generation: <code>$block_short_sha</code> ($block_time) · verify: <a href="$block_api">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+$END_MARKER
+EOF
+}
+
+validate_status() {
+    [ -f status.json ] || fail "status.json is missing"
+    status_size=$(wc -c < status.json | tr -d '[:space:]')
+    [ "$status_size" -le 2048 ] || fail "status.json exceeds 2 KiB"
+    command -v jq >/dev/null 2>&1 || fail "jq is required for --check"
+
+    if ! jq -e \
+        --arg schema "$SCHEMA_URL" \
+        --arg generator "$GENERATOR_VERSION" \
+        --arg freshness "$FRESHNESS_CONTRACT" '
+        type == "object" and
+        ([keys[]] - [
+          "$schema", "schema_version", "generator_version", "repo", "stamp_mode",
+          "generated_at", "describes_commit", "describes_commit_date", "branch",
+          "latest_tag", "latest_release_url", "agents_entry", "canonical_api",
+          "canonical_raw", "freshness_contract"
+        ] | length == 0) and
+        (has("$schema") and has("schema_version") and has("generator_version") and
+         has("repo") and has("stamp_mode") and has("generated_at") and
+         has("describes_commit") and has("describes_commit_date") and has("branch") and
+         has("agents_entry") and has("canonical_api") and has("canonical_raw") and
+         has("freshness_contract")) and
+        .["$schema"] == $schema and
+        .schema_version == 1 and
+        .generator_version == $generator and
+        (.repo | type == "string" and test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")) and
+        (.stamp_mode == "auto" or .stamp_mode == "verify-only") and
+        (.generated_at | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$") and
+          (try (fromdateiso8601 | type == "number") catch false)) and
+        (.describes_commit | type == "string" and test("^[0-9a-f]{40}$")) and
+        (.describes_commit_date | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$") and
+          (try (fromdateiso8601 | type == "number") catch false)) and
+        .generated_at == .describes_commit_date and
+        (.branch | type == "string" and length > 0) and
+        ((has("latest_tag") | not) or .latest_tag == null or
+          (.latest_tag | type == "string" and length > 0)) and
+        ((has("latest_release_url") | not) or .latest_release_url == null or
+          (.latest_release_url | type == "string" and test("^https://github[.]com/"))) and
+        (.agents_entry == "FOR-AGENTS.md" or .agents_entry == "AGENTS.md") and
+        (.canonical_api | type == "string") and
+        (.canonical_raw | type == "string") and
+        .freshness_contract == $freshness
+        ' status.json >/dev/null 2>&1; then
+        fail "status.json is invalid"
+    fi
+
+    status_repo=$(jq -r '.repo' status.json)
+    status_branch=$(jq -r '.branch' status.json)
+    status_sha=$(jq -r '.describes_commit' status.json)
+    status_time=$(jq -r '.generated_at' status.json)
+    status_agents=$(jq -r '.agents_entry' status.json)
+    status_api=$(jq -r '.canonical_api' status.json)
+    status_raw=$(jq -r '.canonical_raw' status.json)
+    expected_api="https://api.github.com/repos/$status_repo/commits/$status_branch"
+    expected_raw="https://raw.githubusercontent.com/$status_repo/$status_sha/status.json"
+
+    [ "$status_agents" = "$agents_entry" ] || fail "status.json agents_entry does not match the repository"
+    [ "$status_api" = "$expected_api" ] || fail "status.json canonical_api is inconsistent"
+    [ "$status_raw" = "$expected_raw" ] || fail "status.json canonical_raw is inconsistent"
+
+    status_short_sha=$(printf '%s' "$status_sha" | cut -c1-7)
+    make_block "$status_short_sha" "$status_time" "$status_api" "$tmp_root/expected-block"
+
+    while IFS= read -r file; do
+        if ! state=$(marker_state "$file"); then
+            fail "malformed repo-state markers in $file"
+        fi
+        [ "$state" = present ] || fail "repo-state markers are missing in $file"
+        awk '
+            index($0, "<!-- repo-state:begin") { inside = 1 }
+            inside { print }
+            index($0, "<!-- repo-state:end") { inside = 0 }
+        ' "$file" > "$tmp_root/actual-block"
+        if ! cmp -s "$tmp_root/expected-block" "$tmp_root/actual-block"; then
+            fail "repo-state stamp in $file is inconsistent with status.json"
+        fi
+    done < "$tmp_root/targets"
+}
+
+if [ "$check_only" = true ]; then
+    validate_status
+    printf '%s\n' "repo-state: check ok"
+    exit 0
+fi
+
+head_sha=$(git rev-parse HEAD 2>/dev/null) || fail "HEAD does not resolve to a commit"
+describes_commit=$head_sha
+while :; do
+    commit_message=$(git show -s --format=%B "$describes_commit")
+    case $commit_message in
+        chore\(repo-state\):*)
+            parent=$(git rev-parse "$describes_commit^" 2>/dev/null) \
+                || fail "stamp commit $describes_commit has no non-stamp ancestor"
+            describes_commit=$parent
+            ;;
+        *) break ;;
+    esac
+done
+
+commit_epoch=$(git show -s --format=%ct "$describes_commit")
+if generated_at=$(date -u -r "$commit_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
+    :
+elif generated_at=$(date -u -d "@$commit_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
+    :
+else
+    fail "could not convert commit date to ISO-8601 UTC"
+fi
+describes_commit_date=$generated_at
+
+if [ -n "${REPO_STATE_REPO:-}" ]; then
+    repo_slug=$REPO_STATE_REPO
+elif [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    repo_slug=$GITHUB_REPOSITORY
+else
+    remote_url=$(git config --get remote.origin.url 2>/dev/null) \
+        || fail "cannot determine repo slug: remote.origin.url is missing"
+    remote_url=${remote_url%.git}
+    case $remote_url in
+        *github.com:*) repo_slug=${remote_url#*github.com:} ;;
+        *github.com/*) repo_slug=${remote_url#*github.com/} ;;
+        *:*) repo_slug=${remote_url#*:} ;;
+        *) fail "cannot determine GitHub repo slug from remote.origin.url" ;;
+    esac
+fi
+printf '%s\n' "$repo_slug" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$' \
+    || fail "invalid GitHub repo slug: $repo_slug"
+
+if [ -n "${REPO_STATE_BRANCH:-}" ]; then
+    branch=$REPO_STATE_BRANCH
+elif branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null); then
+    :
+elif branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); then
+    branch=${branch#origin/}
+else
+    fail "cannot determine branch; set REPO_STATE_BRANCH for a detached checkout"
+fi
+[ -n "$branch" ] || fail "branch is empty"
+printf '%s\n' "$branch" | grep -Eq '^[A-Za-z0-9._/-]+$' \
+    || fail "branch contains characters that cannot be represented safely: $branch"
+
+latest_tag=$(git describe --tags --abbrev=0 "$describes_commit" 2>/dev/null || :)
+latest_release_url=
+if [ "${REPO_STATE_NO_GH:-0}" != 1 ] && command -v gh >/dev/null 2>&1; then
+    if release_fields=$(GH_PROMPT_DISABLED=1 GH_HTTP_TIMEOUT=5 \
+        gh api "repos/$repo_slug/releases/latest" \
+        --jq '[.tag_name, .html_url] | @tsv' 2>/dev/null); then
+        tab=$(printf '\t')
+        case $release_fields in
+            *"$tab"*)
+                latest_tag=${release_fields%%"$tab"*}
+                latest_release_url=${release_fields#*"$tab"}
+                ;;
+        esac
+    fi
+fi
+
+canonical_api="https://api.github.com/repos/$repo_slug/commits/$branch"
+canonical_raw="https://raw.githubusercontent.com/$repo_slug/$describes_commit/status.json"
+
+json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+repo_json=$(json_escape "$repo_slug")
+branch_json=$(json_escape "$branch")
+if [ -n "$latest_tag" ]; then
+    latest_tag_json="\"$(json_escape "$latest_tag")\""
+else
+    latest_tag_json=null
+fi
+if [ -n "$latest_release_url" ]; then
+    latest_release_url_json="\"$(json_escape "$latest_release_url")\""
+else
+    latest_release_url_json=null
+fi
+
+cat > "$tmp_root/status.json" <<EOF
+{
+  "\$schema": "$SCHEMA_URL",
+  "schema_version": 1,
+  "generator_version": "$GENERATOR_VERSION",
+  "repo": "$repo_json",
+  "stamp_mode": "$stamp_mode",
+  "generated_at": "$generated_at",
+  "describes_commit": "$describes_commit",
+  "describes_commit_date": "$describes_commit_date",
+  "branch": "$branch_json",
+  "latest_tag": $latest_tag_json,
+  "latest_release_url": $latest_release_url_json,
+  "agents_entry": "$agents_entry",
+  "canonical_api": "$canonical_api",
+  "canonical_raw": "$canonical_raw",
+  "freshness_contract": "$FRESHNESS_CONTRACT"
+}
+EOF
+
+status_size=$(wc -c < "$tmp_root/status.json" | tr -d '[:space:]')
+[ "$status_size" -le 2048 ] || fail "generated status.json exceeds 2 KiB"
+short_sha=$(printf '%s' "$describes_commit" | cut -c1-7)
+make_block "$short_sha" "$generated_at" "$canonical_api" "$tmp_root/block"
+
+replace_block() {
+    input_file=$1
+    output_file=$2
+    awk -v block_file="$tmp_root/block" '
+        function emit_block(    line) {
+            while ((getline line < block_file) > 0) print line
+            close(block_file)
+        }
+        index($0, "<!-- repo-state:begin") {
+            emit_block()
+            skipping = 1
+            next
+        }
+        skipping && index($0, "<!-- repo-state:end") {
+            skipping = 0
+            next
+        }
+        !skipping { print }
+    ' "$input_file" > "$output_file"
+}
+
+insert_after_h1() {
+    input_file=$1
+    output_file=$2
+    awk -v block_file="$tmp_root/block" '
+        function emit_block(    line) {
+            while ((getline line < block_file) > 0) print line
+            close(block_file)
+        }
+        { print }
+        !inserted && /^#[[:space:]]+[^#]/ {
+            emit_block()
+            inserted = 1
+        }
+    ' "$input_file" > "$output_file"
+}
+
+insert_after_centered_div() {
+    input_file=$1
+    output_file=$2
+    awk -v block_file="$tmp_root/block" '
+        function emit_block(    line) {
+            while ((getline line < block_file) > 0) print line
+            close(block_file)
+        }
+        {
+            print
+            lower = tolower($0)
+            if (index(lower, "<div") &&
+                (index(lower, "align=\"center\"") || index(lower, "align='\''center'\''"))) {
+                centered = 1
+            }
+            if (!inserted && centered && index(lower, "</div>")) {
+                emit_block()
+                inserted = 1
+            }
+        }
+    ' "$input_file" > "$output_file"
+}
+
+file_number=0
+while IFS= read -r file; do
+    file_number=$((file_number + 1))
+    output_file="$tmp_root/stamped-$file_number"
+    state=$(marker_state "$file")
+    if [ "$state" = present ]; then
+        replace_block "$file" "$output_file"
+    elif [ "$file" = "$agents_entry" ]; then
+        insert_after_h1 "$file" "$output_file"
+    elif centered_div_anchor_exists "$file"; then
+        insert_after_centered_div "$file" "$output_file"
+    else
+        insert_after_h1 "$file" "$output_file"
+    fi
+    mv "$output_file" "$file"
+done < "$tmp_root/targets"
+mv "$tmp_root/status.json" status.json
+
+printf '%s\n' "repo-state: generated $short_sha ($generated_at)"

--- a/tools/repo-state-gen.sh
+++ b/tools/repo-state-gen.sh
@@ -5,7 +5,7 @@ set -eu
 PROGRAM=${0##*/}
 SCHEMA_URL=https://raw.githubusercontent.com/caty-ai/family-os/main/docs/repo-state/status.schema.json
 GENERATOR_VERSION='repo-state-gen v1'
-FRESHNESS_CONTRACT='See reader protocol in §2.3; SHA comparison only. A date may only ever trigger distrust, never trust.'
+FRESHNESS_CONTRACT="SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'."
 BEGIN_MARKER='<!-- repo-state:begin (generated; do not edit) -->'
 END_MARKER='<!-- repo-state:end -->'
 
@@ -16,17 +16,25 @@ fail() {
 
 usage() {
     cat >&2 <<EOF
-usage: $PROGRAM [--check] [--stamp-mode auto|verify-only]
+usage: $PROGRAM [--check] [--refresh-release] [--stamp-mode auto|verify-only]
 EOF
     exit 2
 }
 
 check_only=false
 stamp_mode=${REPO_STATE_STAMP_MODE:-auto}
+refresh_release=${REPO_STATE_REFRESH_RELEASE:-0}
+case $refresh_release in
+    0|1) ;;
+    *) fail "REPO_STATE_REFRESH_RELEASE must be 0 or 1" ;;
+esac
 while [ "$#" -gt 0 ]; do
     case $1 in
         --check)
             check_only=true
+            ;;
+        --refresh-release)
+            refresh_release=1
             ;;
         --stamp-mode)
             [ "$#" -ge 2 ] || usage
@@ -286,20 +294,92 @@ fi
 printf '%s\n' "$branch" | grep -Eq '^[A-Za-z0-9._/-]+$' \
     || fail "branch contains characters that cannot be represented safely: $branch"
 
-latest_tag=$(git describe --tags --abbrev=0 "$describes_commit" 2>/dev/null || :)
 latest_release_url=
-if [ "${REPO_STATE_NO_GH:-0}" != 1 ] && command -v gh >/dev/null 2>&1; then
+latest_tag=
+
+decode_json_string_literal() {
+    value=$1
+    value=${value#\"}
+    value=${value%\"}
+    printf '%s' "$value" | sed 's/\\"/"/g; s/\\\\/\\/g'
+}
+
+read_existing_release_field_with_shell() {
+    field_name=$1
+    [ -f status.json ] || return 1
+    field_literal=$(
+        sed -n "s/^[[:space:]]*\"$field_name\"[[:space:]]*:[[:space:]]*//p" status.json \
+            | sed -n '1p' \
+            | sed 's/[[:space:]]*$//; s/,$//'
+    )
+    case $field_literal in
+        '') return 1 ;;
+        null) printf '%s' "" ;;
+        \"*\") decode_json_string_literal "$field_literal" ;;
+        *) return 1 ;;
+    esac
+}
+
+load_existing_release_fields() {
+    [ -f status.json ] || return 0
+    if command -v jq >/dev/null 2>&1; then
+        if existing_tag=$(jq -r 'if has("latest_tag") then .latest_tag // "" else "" end' status.json 2>/dev/null) &&
+            existing_url=$(jq -r 'if has("latest_release_url") then .latest_release_url // "" else "" end' status.json 2>/dev/null); then
+            latest_tag=$existing_tag
+            latest_release_url=$existing_url
+            return 0
+        fi
+    fi
+
+    if existing_tag=$(read_existing_release_field_with_shell latest_tag); then
+        latest_tag=$existing_tag
+    fi
+    if existing_url=$(read_existing_release_field_with_shell latest_release_url); then
+        latest_release_url=$existing_url
+    fi
+}
+
+refresh_release_fields() {
+    [ "${REPO_STATE_NO_GH:-0}" != 1 ] \
+        || fail "release refresh requires gh access; REPO_STATE_NO_GH=1 disables it"
+    command -v gh >/dev/null 2>&1 || fail "gh is required to refresh release metadata"
+
+    gh_error_file=$tmp_root/gh-release.err
     if release_fields=$(GH_PROMPT_DISABLED=1 GH_HTTP_TIMEOUT=5 \
         gh api "repos/$repo_slug/releases/latest" \
-        --jq '[.tag_name, .html_url] | @tsv' 2>/dev/null); then
+        --jq '[.tag_name, .html_url] | @tsv' 2>"$gh_error_file"); then
         tab=$(printf '\t')
         case $release_fields in
             *"$tab"*)
                 latest_tag=${release_fields%%"$tab"*}
                 latest_release_url=${release_fields#*"$tab"}
+                [ -n "$latest_tag" ] || fail "latest release response did not include tag_name"
+                [ -n "$latest_release_url" ] || fail "latest release response did not include html_url"
+                ;;
+            *)
+                fail "latest release response was malformed"
                 ;;
         esac
+        return 0
     fi
+
+    gh_error=$(cat "$gh_error_file")
+    case $gh_error in
+        *"HTTP 404"*)
+            latest_tag=
+            latest_release_url=
+            ;;
+        *)
+            [ -n "$gh_error" ] && printf '%s\n' "$gh_error" >&2
+            fail "could not refresh latest release metadata"
+            ;;
+    esac
+}
+
+if [ "$refresh_release" = 1 ]; then
+    refresh_release_fields
+else
+    load_existing_release_fields
 fi
 
 canonical_api="https://api.github.com/repos/$repo_slug/commits/$branch"

--- a/tools/repo-state-gen.sh
+++ b/tools/repo-state-gen.sh
@@ -24,6 +24,7 @@ EOF
 check_only=false
 stamp_mode=${REPO_STATE_STAMP_MODE:-auto}
 refresh_release=${REPO_STATE_REFRESH_RELEASE:-0}
+gh_bin=${REPO_STATE_GH_BIN:-gh}
 case $refresh_release in
     0|1) ;;
     *) fail "REPO_STATE_REFRESH_RELEASE must be 0 or 1" ;;
@@ -342,11 +343,11 @@ load_existing_release_fields() {
 refresh_release_fields() {
     [ "${REPO_STATE_NO_GH:-0}" != 1 ] \
         || fail "release refresh requires gh access; REPO_STATE_NO_GH=1 disables it"
-    command -v gh >/dev/null 2>&1 || fail "gh is required to refresh release metadata"
+    command -v "$gh_bin" >/dev/null 2>&1 || fail "gh is required to refresh release metadata"
 
     gh_error_file=$tmp_root/gh-release.err
     if release_fields=$(GH_PROMPT_DISABLED=1 GH_HTTP_TIMEOUT=5 \
-        gh api "repos/$repo_slug/releases/latest" \
+        "$gh_bin" api "repos/$repo_slug/releases/latest" \
         --jq '[.tag_name, .html_url] | @tsv' 2>"$gh_error_file"); then
         tab=$(printf '\t')
         case $release_fields in

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+GENERATOR="$ROOT_DIR/tools/repo-state-gen.sh"
+TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/selftest-repo-state.XXXXXX")
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+fail() {
+    printf 'selftest_repo_state_gen: FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected=$1
+    local actual=$2
+    local message=$3
+    [[ "$expected" == "$actual" ]] || fail "$message (expected=$expected actual=$actual)"
+}
+
+new_repo() {
+    local agents_file=$1
+    local repo
+    repo=$(mktemp -d "$TEST_TMP/repo.XXXXXX")
+    git -C "$repo" init -q -b main
+    git -C "$repo" config user.name 'Fixture Author'
+    git -C "$repo" config user.email 'fixture@example.invalid'
+    git -C "$repo" remote add origin https://github.com/fixture/repo.git
+
+    cat > "$repo/README.md" <<'EOF'
+<div align="center">
+# Fixture
+</div>
+
+English introduction.
+EOF
+    cat > "$repo/README.ja.md" <<'EOF'
+# Fixture JA
+
+Japanese introduction.
+EOF
+    cat > "$repo/README.zh.md" <<'EOF'
+# Fixture ZH
+
+Chinese introduction.
+EOF
+    cat > "$repo/README.th.md" <<'EOF'
+# Fixture TH
+
+Thai introduction.
+EOF
+    cat > "$repo/$agents_file" <<'EOF'
+# Agent guide
+
+Route: read the repository guide first.
+EOF
+
+    git -C "$repo" add .
+    GIT_AUTHOR_DATE=2026-08-25T01:02:03Z \
+    GIT_COMMITTER_DATE=2026-08-25T01:02:03Z \
+        git -C "$repo" commit -q -m 'feat: fixture content'
+    printf '%s\n' "$repo"
+}
+
+run_gen() {
+    local repo=$1
+    shift
+    (
+        cd "$repo"
+        REPO_STATE_NO_GH=1 "$GENERATOR" "$@"
+    )
+}
+
+expect_fail() {
+    local message=$1
+    shift
+    if "$@" > "$TEST_TMP/expected-failure.out" 2> "$TEST_TMP/expected-failure.err"; then
+        fail "$message"
+    fi
+    [[ -s "$TEST_TMP/expected-failure.err" ]] || fail "$message did not emit a clear error"
+}
+
+managed_digest() {
+    local repo=$1
+    (
+        cd "$repo"
+        find . -maxdepth 1 -type f \( -name 'README*.md' -o -name 'AGENTS.md' -o -name 'FOR-AGENTS.md' -o -name 'status.json' \) -print \
+            | LC_ALL=C sort \
+            | while IFS= read -r file; do shasum -a 256 "$file"; done \
+            | shasum -a 256 \
+            | awk '{print $1}'
+    )
+}
+
+test_determinism() {
+    local repo first second
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    first=$(managed_digest "$repo")
+    run_gen "$repo" > /dev/null
+    second=$(managed_digest "$repo")
+    assert_eq "$first" "$second" 'two generator runs were not byte-identical'
+    printf 'determinism: byte-identical (%s)\n' "$first"
+}
+
+test_marker_idempotency() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    git -C "$repo" add .
+    GIT_AUTHOR_DATE=2026-08-25T01:03:03Z \
+    GIT_COMMITTER_DATE=2026-08-25T01:03:03Z \
+        git -C "$repo" commit -q -m 'chore(repo-state): fixture'
+    run_gen "$repo" > /dev/null
+    git -C "$repo" diff --quiet || fail 'marker replacement was not idempotent'
+    printf '%s\n' 'marker idempotency: ok'
+}
+
+test_chained_stamp_walk() {
+    local repo content_sha actual_sha
+    repo=$(new_repo FOR-AGENTS.md)
+    content_sha=$(git -C "$repo" rev-parse HEAD)
+    run_gen "$repo" > /dev/null
+    git -C "$repo" add .
+    GIT_AUTHOR_DATE=2026-08-25T01:03:03Z \
+    GIT_COMMITTER_DATE=2026-08-25T01:03:03Z \
+        git -C "$repo" commit -q -m 'chore(repo-state): first'
+    GIT_AUTHOR_DATE=2026-08-25T01:04:03Z \
+    GIT_COMMITTER_DATE=2026-08-25T01:04:03Z \
+        git -C "$repo" commit -q --allow-empty -m 'chore(repo-state): second'
+    run_gen "$repo" > /dev/null
+    actual_sha=$(jq -r '.describes_commit' "$repo/status.json")
+    assert_eq "$content_sha" "$actual_sha" 'describes_commit did not walk over chained stamp commits'
+    assert_eq '2026-08-25T01:02:03Z' "$(jq -r '.generated_at' "$repo/status.json")" 'generated_at was not the content commit date'
+    printf '%s\n' 'chained stamp walk: ok'
+}
+
+test_four_locale_set() {
+    local repo file count
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    count=0
+    for file in README.md README.ja.md README.zh.md README.th.md; do
+        [[ $(grep -c '<!-- repo-state:begin' "$repo/$file") -eq 1 ]] \
+            || fail "$file was not stamped exactly once"
+        count=$((count + 1))
+    done
+    assert_eq 4 "$count" 'four-locale README set was incomplete'
+    assert_eq 1 "$(awk '/<\/div>/{close_line=NR} /repo-state:begin/{print NR-close_line; exit}' "$repo/README.md")" 'centered README stamp position changed'
+    printf '%s\n' 'four-locale README set: ok'
+}
+
+test_agents_resolution() {
+    local repo
+    repo=$(new_repo AGENTS.md)
+    run_gen "$repo" > /dev/null
+    assert_eq AGENTS.md "$(jq -r '.agents_entry' "$repo/status.json")" 'AGENTS.md was not resolved'
+    [[ -f "$repo/AGENTS.md" && ! -e "$repo/FOR-AGENTS.md" ]] || fail 'AGENTS.md fixture was altered incorrectly'
+
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    assert_eq FOR-AGENTS.md "$(jq -r '.agents_entry' "$repo/status.json")" 'FOR-AGENTS.md was not resolved'
+    [[ -f "$repo/FOR-AGENTS.md" && ! -e "$repo/AGENTS.md" ]] || fail 'FOR-AGENTS.md fixture was altered incorrectly'
+    printf '%s\n' 'agents entry resolution: ok'
+}
+
+test_malformed_marker_error() {
+    local repo before after
+    repo=$(new_repo FOR-AGENTS.md)
+    printf '%s\n' '<!-- repo-state:begin (generated; do not edit) -->' >> "$repo/README.md"
+    before=$(shasum -a 256 "$repo/README.md" | awk '{print $1}')
+    expect_fail 'begin marker without end marker was accepted' run_gen "$repo"
+    after=$(shasum -a 256 "$repo/README.md" | awk '{print $1}')
+    assert_eq "$before" "$after" 'malformed-marker failure modified the README'
+    [[ ! -e "$repo/status.json" ]] || fail 'malformed-marker failure wrote status.json'
+    printf '%s\n' 'malformed marker hard error: ok'
+}
+
+test_check_markerless_readme() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    cat > "$repo/README.extra.md" <<'EOF'
+# Newly added locale
+
+This file has no stamp yet.
+EOF
+    expect_fail '--check accepted a marker-less root README' run_gen "$repo" --check
+    grep -q 'markers are missing in README.extra.md' "$TEST_TMP/expected-failure.err" \
+        || fail '--check marker-less error did not identify the file'
+    printf '%s\n' '--check marker-less README: red as expected'
+}
+
+test_check_cross_file_mismatch() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    sed 's/generation: <code>[0-9a-f][0-9a-f]*/generation: <code>0000000/' "$repo/README.ja.md" \
+        > "$repo/README.ja.md.tmp"
+    mv "$repo/README.ja.md.tmp" "$repo/README.ja.md"
+    expect_fail '--check accepted a cross-file stamp mismatch' run_gen "$repo" --check
+    grep -q 'inconsistent with status.json' "$TEST_TMP/expected-failure.err" \
+        || fail '--check mismatch error was unclear'
+    printf '%s\n' '--check cross-file mismatch: red as expected'
+}
+
+test_check_invalid_status() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    sed 's/"schema_version": 1/"schema_version": 2/' "$repo/status.json" > "$repo/status.json.tmp"
+    mv "$repo/status.json.tmp" "$repo/status.json"
+    expect_fail '--check accepted an invalid status.json' run_gen "$repo" --check
+    grep -q 'status.json is invalid' "$TEST_TMP/expected-failure.err" \
+        || fail '--check invalid-status error was unclear'
+    printf '%s\n' '--check invalid status: red as expected'
+}
+
+test_check_missing_status() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    expect_fail '--check accepted a missing status.json' run_gen "$repo" --check
+    grep -q 'status.json is missing' "$TEST_TMP/expected-failure.err" \
+        || fail '--check missing-status error was unclear'
+    printf '%s\n' '--check missing status: red as expected'
+}
+
+test_check_healthy() {
+    local repo output
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    output=$(run_gen "$repo" --check)
+    assert_eq 'repo-state: check ok' "$output" '--check rejected a healthy tree'
+    printf '%s\n' '--check healthy tree: green'
+}
+
+test_verify_only_mode() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" --stamp-mode verify-only > /dev/null
+    assert_eq verify-only "$(jq -r '.stamp_mode' "$repo/status.json")" 'verify-only mode was not recorded'
+    run_gen "$repo" --check > /dev/null
+    printf '%s\n' 'verify-only mode: ok'
+}
+
+test_determinism
+test_marker_idempotency
+test_chained_stamp_walk
+test_four_locale_set
+test_agents_resolution
+test_malformed_marker_error
+test_check_markerless_readme
+test_check_cross_file_mismatch
+test_check_invalid_status
+test_check_missing_status
+test_check_healthy
+test_verify_only_mode
+
+printf '%s\n' 'selftest_repo_state_gen: ok'

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 GENERATOR="$ROOT_DIR/tools/repo-state-gen.sh"
 TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/selftest-repo-state.XXXXXX")
+REAL_GIT=$(command -v git)
 trap 'rm -rf "$TEST_TMP"' EXIT
 
 fail() {
@@ -68,7 +69,7 @@ run_gen() {
     shift
     (
         cd "$repo"
-        REPO_STATE_NO_GH=1 "$GENERATOR" "$@"
+        REPO_STATE_NO_GH="${REPO_STATE_NO_GH:-1}" "$GENERATOR" "$@"
     )
 }
 
@@ -93,11 +94,58 @@ managed_digest() {
     )
 }
 
+path_without_gh() {
+    local gh_path gh_dir filtered path_entry
+    gh_path=$(command -v gh 2>/dev/null || true)
+    [[ -n "$gh_path" ]] || {
+        printf '%s\n' "$PATH"
+        return 0
+    }
+    gh_dir=$(dirname "$gh_path")
+    filtered=
+    IFS=':' read -r -a path_parts <<< "$PATH"
+    for path_entry in "${path_parts[@]}"; do
+        [[ "$path_entry" == "$gh_dir" ]] && continue
+        filtered=${filtered:+$filtered:}$path_entry
+    done
+    printf '%s\n' "$filtered"
+}
+
+seed_release_fields() {
+    local repo=$1
+    local tag=$2
+    local url=$3
+    jq --arg tag "$tag" --arg url "$url" \
+        '.latest_tag = $tag | .latest_release_url = $url' \
+        "$repo/status.json" > "$repo/status.json.tmp"
+    mv "$repo/status.json.tmp" "$repo/status.json"
+}
+
+make_git_wrapper_without_describe() {
+    local dir=$1
+    local marker=$2
+    cat > "$dir/git" <<EOF
+#!/bin/bash
+set -euo pipefail
+if [[ "\${1-}" == describe ]]; then
+    printf '%s\n' 'git describe' >> "$marker"
+    exit 97
+fi
+exec "$REAL_GIT" "\$@"
+EOF
+    chmod +x "$dir/git"
+}
+
 test_determinism() {
-    local repo first second
+    local repo first second describes_commit expected_generated_at
     repo=$(new_repo FOR-AGENTS.md)
     run_gen "$repo" > /dev/null
+    describes_commit=$(jq -r '.describes_commit' "$repo/status.json")
+    expected_generated_at=$(git -C "$repo" show -s --format=%cI "$describes_commit" | sed 's/+00:00$/Z/')
+    assert_eq "$expected_generated_at" "$(jq -r '.generated_at' "$repo/status.json")" \
+        'generated_at did not equal the describes_commit committer date'
     first=$(managed_digest "$repo")
+    sleep 2
     run_gen "$repo" > /dev/null
     second=$(managed_digest "$repo")
     assert_eq "$first" "$second" 'two generator runs were not byte-identical'
@@ -177,6 +225,17 @@ test_malformed_marker_error() {
     printf '%s\n' 'malformed marker hard error: ok'
 }
 
+test_check_malformed_marker_error() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    printf '%s\n' '<!-- repo-state:begin (generated; do not edit) -->' >> "$repo/README.md"
+    expect_fail '--check accepted malformed repo-state markers' run_gen "$repo" --check
+    grep -q 'malformed repo-state markers in README.md' "$TEST_TMP/expected-failure.err" \
+        || fail '--check malformed-marker error did not identify README.md'
+    printf '%s\n' '--check malformed marker: red as expected'
+}
+
 test_check_markerless_readme() {
     local repo
     repo=$(new_repo FOR-AGENTS.md)
@@ -244,17 +303,255 @@ test_verify_only_mode() {
     printf '%s\n' 'verify-only mode: ok'
 }
 
+test_agents_entry_conflict() {
+    local repo
+    repo=$(new_repo AGENTS.md)
+    cp "$repo/AGENTS.md" "$repo/FOR-AGENTS.md"
+    expect_fail 'generator accepted both AGENTS.md and FOR-AGENTS.md' run_gen "$repo"
+    grep -q 'agents_entry is ambiguous' "$TEST_TMP/expected-failure.err" \
+        || fail 'agents-entry conflict error was unclear'
+    printf '%s\n' 'agents entry conflict: red as expected'
+}
+
+test_anchorless_readme_error() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    cat > "$repo/README.zh.md" <<'EOF'
+This README has no centered header.
+It also has no H1 anchor.
+EOF
+    expect_fail 'generator accepted an anchor-less README in auto mode' run_gen "$repo"
+    grep -q 'cannot insert stamp in README.zh.md' "$TEST_TMP/expected-failure.err" \
+        || fail 'anchor-less README error was unclear'
+    [[ ! -e "$repo/status.json" ]] || fail 'anchor-less README failure wrote status.json'
+    printf '%s\n' 'anchor-less README: red as expected'
+}
+
+test_release_fields_preserved_without_refresh() {
+    local repo mock_dir git_marker gh_marker before after
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    seed_release_fields "$repo" 'v1.2.3' 'https://github.com/fixture/repo/releases/tag/v1.2.3'
+    before=$(managed_digest "$repo")
+
+    mock_dir=$(mktemp -d "$TEST_TMP/mock-preserve.XXXXXX")
+    git_marker="$mock_dir/git-describe.log"
+    gh_marker="$mock_dir/gh.log"
+    make_git_wrapper_without_describe "$mock_dir" "$git_marker"
+    cat > "$mock_dir/gh" <<EOF
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' 'gh called unexpectedly' >> "$gh_marker"
+exit 96
+EOF
+    chmod +x "$mock_dir/gh"
+
+    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 run_gen "$repo" > /dev/null
+    after=$(managed_digest "$repo")
+
+    assert_eq 'v1.2.3' "$(jq -r '.latest_tag' "$repo/status.json")" 'ordinary run did not preserve latest_tag'
+    assert_eq 'https://github.com/fixture/repo/releases/tag/v1.2.3' "$(jq -r '.latest_release_url' "$repo/status.json")" \
+        'ordinary run did not preserve latest_release_url'
+    assert_eq "$before" "$after" 'ordinary run was not byte-identical after preserving release fields'
+    [[ ! -e "$git_marker" ]] || fail 'ordinary run invoked git describe'
+    [[ ! -e "$gh_marker" ]] || fail 'ordinary run invoked gh'
+    printf '%s\n' 'ordinary release fields: preserved without refresh'
+}
+
+test_normal_run_without_gh_on_path() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    PATH="$(path_without_gh)" REPO_STATE_NO_GH=0 run_gen "$repo" > /dev/null
+    run_gen "$repo" --check > /dev/null
+    printf '%s\n' 'ordinary run without gh on PATH: green'
+}
+
+test_refresh_release_without_gh_on_path_fails() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    expect_fail 'refresh-release without gh on PATH was accepted' \
+        env PATH="$(path_without_gh)" REPO_STATE_NO_GH=0 \
+        bash -lc "cd \"\$1\" && exec \"\$2\" --refresh-release" _ "$repo" "$GENERATOR"
+    grep -q 'gh is required to refresh release metadata' "$TEST_TMP/expected-failure.err" \
+        || fail 'refresh-release without gh on PATH did not emit a clear gh-missing error'
+    [[ ! -e "$repo/status.json" ]] || fail 'refresh-release without gh on PATH wrote status.json'
+    printf '%s\n' 'refresh-release without gh on PATH: red as expected'
+}
+
+test_refresh_release_flag_queries_gh() {
+    local repo mock_dir git_marker gh_args
+    repo=$(new_repo FOR-AGENTS.md)
+    mock_dir=$(mktemp -d "$TEST_TMP/mock-refresh-flag.XXXXXX")
+    git_marker="$mock_dir/git-describe.log"
+    gh_args="$mock_dir/gh-args.log"
+    make_git_wrapper_without_describe "$mock_dir" "$git_marker"
+    cat > "$mock_dir/gh" <<EOF
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "\$*" > "$gh_args"
+if [[ "\${1-}" == api && "\${2-}" == repos/fixture/repo/releases/latest ]]; then
+    printf 'v2.0.0\thttps://github.com/fixture/repo/releases/tag/v2.0.0\n'
+    exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "\$*" >&2
+exit 98
+EOF
+    chmod +x "$mock_dir/gh"
+
+    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 run_gen "$repo" --refresh-release > /dev/null
+
+    assert_eq 'v2.0.0' "$(jq -r '.latest_tag' "$repo/status.json")" '--refresh-release did not update latest_tag'
+    assert_eq 'https://github.com/fixture/repo/releases/tag/v2.0.0' "$(jq -r '.latest_release_url' "$repo/status.json")" \
+        '--refresh-release did not update latest_release_url'
+    grep -q 'repos/fixture/repo/releases/latest' "$gh_args" \
+        || fail '--refresh-release did not query releases/latest'
+    [[ ! -e "$git_marker" ]] || fail '--refresh-release invoked git describe'
+    printf '%s\n' '--refresh-release flag: ok'
+}
+
+test_refresh_release_env_queries_gh() {
+    local repo mock_dir git_marker
+    repo=$(new_repo FOR-AGENTS.md)
+    mock_dir=$(mktemp -d "$TEST_TMP/mock-refresh-env.XXXXXX")
+    git_marker="$mock_dir/git-describe.log"
+    make_git_wrapper_without_describe "$mock_dir" "$git_marker"
+    cat > "$mock_dir/gh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "${1-}" == api && "${2-}" == repos/fixture/repo/releases/latest ]]; then
+    printf 'v3.0.0\thttps://github.com/fixture/repo/releases/tag/v3.0.0\n'
+    exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 98
+EOF
+    chmod +x "$mock_dir/gh"
+
+    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 REPO_STATE_REFRESH_RELEASE=1 run_gen "$repo" > /dev/null
+
+    assert_eq 'v3.0.0' "$(jq -r '.latest_tag' "$repo/status.json")" 'REPO_STATE_REFRESH_RELEASE=1 did not update latest_tag'
+    assert_eq 'https://github.com/fixture/repo/releases/tag/v3.0.0' "$(jq -r '.latest_release_url' "$repo/status.json")" \
+        'REPO_STATE_REFRESH_RELEASE=1 did not update latest_release_url'
+    [[ ! -e "$git_marker" ]] || fail 'REPO_STATE_REFRESH_RELEASE=1 invoked git describe'
+    printf '%s\n' 'refresh-release env flag: ok'
+}
+
+test_refresh_release_404_maps_null() {
+    local repo mock_dir git_marker
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    seed_release_fields "$repo" 'v9.9.9' 'https://github.com/fixture/repo/releases/tag/v9.9.9'
+
+    mock_dir=$(mktemp -d "$TEST_TMP/mock-refresh-404.XXXXXX")
+    git_marker="$mock_dir/git-describe.log"
+    make_git_wrapper_without_describe "$mock_dir" "$git_marker"
+    cat > "$mock_dir/gh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' 'gh: Not Found (HTTP 404)' >&2
+exit 1
+EOF
+    chmod +x "$mock_dir/gh"
+
+    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 run_gen "$repo" --refresh-release > /dev/null
+
+    jq -e '.latest_tag == null and .latest_release_url == null' "$repo/status.json" > /dev/null \
+        || fail 'HTTP 404 did not map release fields to null'
+    [[ ! -e "$git_marker" ]] || fail '404 refresh invoked git describe'
+    printf '%s\n' 'refresh-release 404: null as expected'
+}
+
+test_refresh_release_transport_error_is_fatal() {
+    local repo mock_dir before after
+    repo=$(new_repo FOR-AGENTS.md)
+    mock_dir=$(mktemp -d "$TEST_TMP/mock-refresh-transport.XXXXXX")
+    make_git_wrapper_without_describe "$mock_dir" "$mock_dir/git-describe.log"
+    cat > "$mock_dir/gh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' 'Get "https://api.github.com/repos/fixture/repo/releases/latest": dial tcp: lookup api.github.com: no such host' >&2
+exit 1
+EOF
+    chmod +x "$mock_dir/gh"
+
+    before=$(shasum -a 256 "$repo/README.md" | awk '{print $1}')
+    expect_fail 'transport failure during release refresh was accepted' \
+        env PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 \
+        bash -lc "cd \"\$1\" && exec \"\$2\" --refresh-release" _ "$repo" "$GENERATOR"
+    after=$(shasum -a 256 "$repo/README.md" | awk '{print $1}')
+    assert_eq "$before" "$after" 'transport refresh failure modified README.md'
+    [[ ! -e "$repo/status.json" ]] || fail 'transport refresh failure wrote status.json'
+    grep -q 'could not refresh latest release metadata' "$TEST_TMP/expected-failure.err" \
+        || fail 'transport refresh failure did not emit a clear fatal error'
+    printf '%s\n' 'refresh-release transport failure: red as expected'
+}
+
+test_refresh_release_http_error_is_fatal() {
+    local repo mock_dir
+    repo=$(new_repo FOR-AGENTS.md)
+    mock_dir=$(mktemp -d "$TEST_TMP/mock-refresh-http.XXXXXX")
+    make_git_wrapper_without_describe "$mock_dir" "$mock_dir/git-describe.log"
+    cat > "$mock_dir/gh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' 'gh: Internal Server Error (HTTP 500)' >&2
+exit 1
+EOF
+    chmod +x "$mock_dir/gh"
+
+    expect_fail 'HTTP 500 during release refresh was accepted' \
+        env PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 \
+        bash -lc "cd \"\$1\" && exec \"\$2\" --refresh-release" _ "$repo" "$GENERATOR"
+    [[ ! -e "$repo/status.json" ]] || fail 'HTTP 500 refresh failure wrote status.json'
+    grep -q 'could not refresh latest release metadata' "$TEST_TMP/expected-failure.err" \
+        || fail 'HTTP 500 refresh failure did not emit a clear fatal error'
+    printf '%s\n' 'refresh-release HTTP failure: red as expected'
+}
+
+test_freshness_contract_literal_alignment() {
+    local expected
+    expected="SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'."
+    grep -Fq "$expected" "$GENERATOR" || fail 'generator freshness_contract literal drifted'
+    grep -Fq "$expected" "$ROOT_DIR/docs/repo-state/status.schema.json" \
+        || fail 'status schema freshness_contract literal drifted'
+    grep -Fq "$expected" "$ROOT_DIR/docs/repo-state/spec.md" \
+        || fail 'spec freshness_contract literal drifted'
+    printf '%s\n' 'freshness contract literal: aligned'
+}
+
+test_repo_state_docs_citations() {
+    if grep -R -nE '§2\.3|§2\.6' \
+        "$ROOT_DIR/docs/repo-state" "$GENERATOR" > "$TEST_TMP/stale-citations.out"; then
+        cat "$TEST_TMP/stale-citations.out" >&2
+        fail 'stale repo-state section citations remain'
+    fi
+    printf '%s\n' 'repo-state citations: clean'
+}
+
 test_determinism
 test_marker_idempotency
 test_chained_stamp_walk
 test_four_locale_set
 test_agents_resolution
+test_agents_entry_conflict
+test_anchorless_readme_error
 test_malformed_marker_error
+test_check_malformed_marker_error
 test_check_markerless_readme
 test_check_cross_file_mismatch
 test_check_invalid_status
 test_check_missing_status
 test_check_healthy
 test_verify_only_mode
+test_release_fields_preserved_without_refresh
+test_normal_run_without_gh_on_path
+test_refresh_release_without_gh_on_path_fails
+test_refresh_release_flag_queries_gh
+test_refresh_release_env_queries_gh
+test_refresh_release_404_maps_null
+test_refresh_release_transport_error_is_fatal
+test_refresh_release_http_error_is_fatal
+test_freshness_contract_literal_alignment
+test_repo_state_docs_citations
 
 printf '%s\n' 'selftest_repo_state_gen: ok'

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -26,7 +26,7 @@ new_repo() {
     repo=$(mktemp -d "$TEST_TMP/repo.XXXXXX")
     git -C "$repo" init -q -b main
     git -C "$repo" config user.name 'Fixture Author'
-    git -C "$repo" config user.email 'fixture@example.invalid'
+    git -C "$repo" config user.email 'fixture@localhost'
     git -C "$repo" remote add origin https://github.com/fixture/repo.git
 
     cat > "$repo/README.md" <<'EOF'
@@ -92,23 +92,6 @@ managed_digest() {
             | shasum -a 256 \
             | awk '{print $1}'
     )
-}
-
-path_without_gh() {
-    local gh_path gh_dir filtered path_entry
-    gh_path=$(command -v gh 2>/dev/null || true)
-    [[ -n "$gh_path" ]] || {
-        printf '%s\n' "$PATH"
-        return 0
-    }
-    gh_dir=$(dirname "$gh_path")
-    filtered=
-    IFS=':' read -r -a path_parts <<< "$PATH"
-    for path_entry in "${path_parts[@]}"; do
-        [[ "$path_entry" == "$gh_dir" ]] && continue
-        filtered=${filtered:+$filtered:}$path_entry
-    done
-    printf '%s\n' "$filtered"
 }
 
 seed_release_fields() {
@@ -346,7 +329,7 @@ exit 96
 EOF
     chmod +x "$mock_dir/gh"
 
-    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 run_gen "$repo" > /dev/null
+    PATH="$mock_dir:$PATH" REPO_STATE_GH_BIN="$mock_dir/gh" REPO_STATE_NO_GH=0 run_gen "$repo" > /dev/null
     after=$(managed_digest "$repo")
 
     assert_eq 'v1.2.3' "$(jq -r '.latest_tag' "$repo/status.json")" 'ordinary run did not preserve latest_tag'
@@ -361,7 +344,7 @@ EOF
 test_normal_run_without_gh_on_path() {
     local repo
     repo=$(new_repo FOR-AGENTS.md)
-    PATH="$(path_without_gh)" REPO_STATE_NO_GH=0 run_gen "$repo" > /dev/null
+    REPO_STATE_GH_BIN=/nonexistent/gh REPO_STATE_NO_GH=0 run_gen "$repo" > /dev/null
     run_gen "$repo" --check > /dev/null
     printf '%s\n' 'ordinary run without gh on PATH: green'
 }
@@ -370,7 +353,7 @@ test_refresh_release_without_gh_on_path_fails() {
     local repo
     repo=$(new_repo FOR-AGENTS.md)
     expect_fail 'refresh-release without gh on PATH was accepted' \
-        env PATH="$(path_without_gh)" REPO_STATE_NO_GH=0 \
+        env REPO_STATE_GH_BIN=/nonexistent/gh REPO_STATE_NO_GH=0 \
         bash -lc "cd \"\$1\" && exec \"\$2\" --refresh-release" _ "$repo" "$GENERATOR"
     grep -q 'gh is required to refresh release metadata' "$TEST_TMP/expected-failure.err" \
         || fail 'refresh-release without gh on PATH did not emit a clear gh-missing error'
@@ -398,7 +381,7 @@ exit 98
 EOF
     chmod +x "$mock_dir/gh"
 
-    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 run_gen "$repo" --refresh-release > /dev/null
+    PATH="$mock_dir:$PATH" REPO_STATE_GH_BIN="$mock_dir/gh" REPO_STATE_NO_GH=0 run_gen "$repo" --refresh-release > /dev/null
 
     assert_eq 'v2.0.0' "$(jq -r '.latest_tag' "$repo/status.json")" '--refresh-release did not update latest_tag'
     assert_eq 'https://github.com/fixture/repo/releases/tag/v2.0.0' "$(jq -r '.latest_release_url' "$repo/status.json")" \
@@ -427,7 +410,7 @@ exit 98
 EOF
     chmod +x "$mock_dir/gh"
 
-    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 REPO_STATE_REFRESH_RELEASE=1 run_gen "$repo" > /dev/null
+    PATH="$mock_dir:$PATH" REPO_STATE_GH_BIN="$mock_dir/gh" REPO_STATE_NO_GH=0 REPO_STATE_REFRESH_RELEASE=1 run_gen "$repo" > /dev/null
 
     assert_eq 'v3.0.0' "$(jq -r '.latest_tag' "$repo/status.json")" 'REPO_STATE_REFRESH_RELEASE=1 did not update latest_tag'
     assert_eq 'https://github.com/fixture/repo/releases/tag/v3.0.0' "$(jq -r '.latest_release_url' "$repo/status.json")" \
@@ -453,7 +436,7 @@ exit 1
 EOF
     chmod +x "$mock_dir/gh"
 
-    PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 run_gen "$repo" --refresh-release > /dev/null
+    PATH="$mock_dir:$PATH" REPO_STATE_GH_BIN="$mock_dir/gh" REPO_STATE_NO_GH=0 run_gen "$repo" --refresh-release > /dev/null
 
     jq -e '.latest_tag == null and .latest_release_url == null' "$repo/status.json" > /dev/null \
         || fail 'HTTP 404 did not map release fields to null'
@@ -476,7 +459,7 @@ EOF
 
     before=$(shasum -a 256 "$repo/README.md" | awk '{print $1}')
     expect_fail 'transport failure during release refresh was accepted' \
-        env PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 \
+        env PATH="$mock_dir:$PATH" REPO_STATE_GH_BIN="$mock_dir/gh" REPO_STATE_NO_GH=0 \
         bash -lc "cd \"\$1\" && exec \"\$2\" --refresh-release" _ "$repo" "$GENERATOR"
     after=$(shasum -a 256 "$repo/README.md" | awk '{print $1}')
     assert_eq "$before" "$after" 'transport refresh failure modified README.md'
@@ -500,7 +483,7 @@ EOF
     chmod +x "$mock_dir/gh"
 
     expect_fail 'HTTP 500 during release refresh was accepted' \
-        env PATH="$mock_dir:$PATH" REPO_STATE_NO_GH=0 \
+        env PATH="$mock_dir:$PATH" REPO_STATE_GH_BIN="$mock_dir/gh" REPO_STATE_NO_GH=0 \
         bash -lc "cd \"\$1\" && exec \"\$2\" --refresh-release" _ "$repo" "$GENERATOR"
     [[ ! -e "$repo/status.json" ]] || fail 'HTTP 500 refresh failure wrote status.json'
     grep -q 'could not refresh latest release metadata' "$TEST_TMP/expected-failure.err" \

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -2,6 +2,16 @@
 
 set -euo pipefail
 
+unset \
+    GITHUB_REPOSITORY \
+    GH_REPO \
+    REPO_STATE_BRANCH \
+    REPO_STATE_GH_BIN \
+    REPO_STATE_NO_GH \
+    REPO_STATE_REFRESH_RELEASE \
+    REPO_STATE_REPO \
+    REPO_STATE_STAMP_MODE
+
 ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 GENERATOR="$ROOT_DIR/tools/repo-state-gen.sh"
 TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/selftest-repo-state.XXXXXX")
@@ -194,6 +204,15 @@ test_agents_resolution() {
     assert_eq FOR-AGENTS.md "$(jq -r '.agents_entry' "$repo/status.json")" 'FOR-AGENTS.md was not resolved'
     [[ -f "$repo/FOR-AGENTS.md" && ! -e "$repo/AGENTS.md" ]] || fail 'FOR-AGENTS.md fixture was altered incorrectly'
     printf '%s\n' 'agents entry resolution: ok'
+}
+
+test_github_repository_precedence() {
+    local repo
+    repo=$(new_repo FOR-AGENTS.md)
+    GITHUB_REPOSITORY=explicit/repository run_gen "$repo" > /dev/null
+    assert_eq explicit/repository "$(jq -r '.repo' "$repo/status.json")" \
+        'GITHUB_REPOSITORY did not override the fixture remote'
+    printf '%s\n' 'GITHUB_REPOSITORY precedence: ok'
 }
 
 test_malformed_marker_error() {
@@ -516,6 +535,7 @@ test_marker_idempotency
 test_chained_stamp_walk
 test_four_locale_set
 test_agents_resolution
+test_github_repository_precedence
 test_agents_entry_conflict
 test_anchorless_readme_error
 test_malformed_marker_error


### PR DESCRIPTION
Implements the repo-state core in family-os per the 3-seat-reviewed DESIGN v0.2 (caty-ai/family-os#127).

## Files changed (declared set — matches `git diff origin/main --stat`, 7 files, +1244)

- `docs/repo-state/DESIGN.md` — design record (v0.2, byte-identical to the reviewed text, sha256 `433afe07…`)
- `docs/repo-state/spec.md` — normative spec incl. the SHA-based reader protocol
- `docs/repo-state/status.schema.json` — status.json JSON Schema
- `tools/repo-state-gen.sh` — deterministic POSIX generator (stamp + status.json + `--check`)
- `tools/selftest_repo_state_gen.sh` — selftest (determinism, idempotency, describes_commit walk over chained stamps, 4-locale set, AGENTS/FOR-AGENTS resolution, malformed-marker hard error, --check red/green, verify-only mode)
- `.github/workflows/repo-state.yml` — reusable workflow (update + check jobs, event-scoped guards)
- `Makefile` — selftest wiring (1 line)

NOT touched: README*, FOR-AGENTS.md, registry, family-links.yml (rollout + audit extension are separate child issues per #127).

## Evidence

- `bash tools/selftest_repo_state_gen.sh` → ok (implementer run + independent rerun by Alpha)
- Existing suites unchanged and green: publication gate (60 assertions) / registry offline / render --check / footer selftest
- `shellcheck` clean, `actionlint` clean
- Determinism: two-run byte-identical (sha256 `f0d70ae…`)
- Implementation writer: Codex GPT-5.6 Sol; staging/commit by Alpha (writer sandbox cannot write shared worktree git metadata — deviation recorded in #127 lane log)

## Merge plan

L-size: 3-seat heterogeneous merge review runs next on this exact head; results will be posted here with requested/actual models and verdicts. This PR touches `.github/workflows/**` → DEFAULT risk path: needs 翔さん's human label before merge (planned from the start). Completion record per L1-7 will be added to this PR body before merge.

Part of caty-ai/family-os#127.


---

## Completion record (L1-7) — PR #129, candidate SHA f08335f

**Candidate SHA**: `f08335f` (= PR head; chain aa4cd9f core → 89d7d08 review delta R1-R3 → 3fdfa2f CI-hygiene delta2 C1-C3 → f08335f hermetic-selftest delta3)
**Implementer**: Codex GPT-5.6 Sol (profile sol, 3 sitter-monitored runs); staging/commits by Alpha (writer sandbox cannot write shared worktree git metadata). **Reviewers**: see merge-review record comment above.

### Done when (this PR's scope, from #127 checklist item 1 + parts of 7)

| Item | Status | Evidence (inline, 2026-08-25) |
|---|---|---|
| status.schema.json + spec page incl. SHA-based reader protocol | PASS | `docs/repo-state/status.schema.json`, `docs/repo-state/spec.md` §3 "Reader protocol — SHA-based, never date-based"; 3-seat convergent CRITICAL encoded; citation-consistency guarded by selftest ("repo-state citations: clean") |
| Deterministic generator | PASS | Two-run digest identical with AND without gh reachable: `2844485e…` == `2844485e…` (Opus delta verification, delta head); `generated_at` == committer date of describes_commit (mutation test red when broken: "FAIL: generated_at did not equal the describes_commit committer date") |
| Selftest wired into Makefile, tests real | PASS | 26 tests green in CI (`selftest_repo_state_gen: ok`, test-lint ubuntu+macos); 5 independent mutation experiments across 3 seats + Opus delta re-mutation — every mutation red (walk break / wall-clock / cross-file cmp / carry-forward neutered) |
| Reusable workflow update+check jobs, event-scoped guards | PASS | `.github/workflows/repo-state.yml`; actionlint clean; release/dispatch never skipped, refresh env set only there, both initial and post-rebase retry paths (Opus delta verification: repo-state.yml:86-97,120); loop-stopper = determinism, verified on real 3-deep stamp chain (zero diff → no commit) |
| No release-field network dependence on push runs (review R1) | PASS | carried forward from prior status.json; refresh mode fatal+loud on transport/HTTP failure, 404 = valid null (Opus delta evidence: EXIT_A/B/C=1, EXIT_D=0) |
| Publication hygiene | PASS | publication gate green on 3fdfa2f (no personal-name / email-shaped strings in the new files) |
| Declared file set == diff | PASS | 7 files, no README/FOR-AGENTS/registry/family-links changes (`git diff origin/main --stat` matches PR body list; WIP declaration on #127 honored) |

### Review

- L1-9 pre-implementation design review: 3 heterogeneous seats (Kimi K3 / Grok 4.6 / GLM 5.3), all GO-WITH-CHANGES → all blocking findings folded into DESIGN v0.2 before implementation.
- L1-9 merge review at aa4cd9f: Opus 5 GO-WITH-CHANGES / GLM 5.3 GO / Kimi K3 GO; adjudication + delta R1-R3; **Opus (finding seat) delta verification: F1/F4/F2 RESOLVED, cumulative GO**. Writer (codex-sol) heterogeneous from all seats; Alpha not counted as a review vote.
- Non-blocking follow-ups recorded in the review-record comment (fence-aware markers, generator checksum pin, actor-guard breadth, 404-vs-missing-repo disambiguation, audit + L0-5 exception sequencing gated at first-caller PR).

### CI

All checks green on f08335f (2026-08-25: publication gate / test-lint ubuntu+macos / gitleaks / history / links / registry reality ×2 / footer / evidence freshness) except the two label-gated ones by design: `risk-review-gate` (workflows path → owner label) and `pr-size` (1655 lines > 250 → owner `size-exempt` label; size dominated by the vendored design record + 26-test suite). CI-environment deltas were real portability finds: gh present at /usr/bin on runners (delta2 C3) and ambient GITHUB_REPOSITORY leaking into fixtures (delta3) — both now covered by hermetic tests.

### Release

- **release**: this merge is norm-changing (org-wide freshness canon + reusable workflow) → ship-relevant. Plan: annotated tag `v0.11.0` + GitHub Release on family-os immediately after merge (family-os has no release-sync carrier → manual `gh release create` in-repo). Callers will pin this tag (GLM F5: header example must reference it).
- **previous release**: `v0.10.0`.

### Owner actions requested (翔さん)

1. Apply label `size-exempt` to PR #129 (head f08335f — the label is voided by any new push, and no further push is planned).
2. Apply the risk-review-gate human label (DEFAULT risk path; workflows file).
3. Merge decision. After merge, Alpha cuts `v0.11.0` + Release and updates #127 checklist.
