### PR TITLE
repo-state: caller workflow + initial stamp (pin v0.11.0)

### DIFF
--- a/.github/workflows/repo-state-caller.yml
+++ b/.github/workflows/repo-state-caller.yml
@@ -1,0 +1,22 @@
+name: repository state
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: repo-state-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  repo-state:
+    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.0
+    with:
+      generator_ref: v0.11.0

--- a/.github/workflows/repo-state-caller.yml
+++ b/.github/workflows/repo-state-caller.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   repo-state:
-    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.0
+    uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.12.1
+    secrets: inherit
     with:
-      generator_ref: v0.11.0
+      generator_ref: v0.12.1

--- a/FOR-AGENTS.md
+++ b/FOR-AGENTS.md
@@ -1,4 +1,7 @@
 # FOR-AGENTS.md — for the AI agent visiting this repository
+<!-- repo-state:begin (generated; do not edit) -->
+<p align="center"><sub>generation: <code>105f91d</code> (2026-08-25T16:04:43Z) · verify: <a href="https://api.github.com/repos/caty-ai/family-os/commits/feat/repo-state-caller-131">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<!-- repo-state:end -->
 
 ## 1. About this file
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -26,6 +26,9 @@ Family OS は、その一つひとつに効く仕組みが**どこにあるか**
 🔧 [エンジニア向けドキュメント](docs/engineering.ja.md) ｜ 📘 [詳細仕様](docs/reference.ja.md)
 
 </div>
+<!-- repo-state:begin (generated; do not edit) -->
+<p align="center"><sub>generation: <code>105f91d</code> (2026-08-25T16:04:43Z) · verify: <a href="https://api.github.com/repos/caty-ai/family-os/commits/feat/repo-state-caller-131">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<!-- repo-state:end -->
 
 - [こんな経験はありませんか？](#problems)
 - [作り直すのではなく、育てる](#why)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Every part runs on its own, so you can take just the one you need today.
 🔧 [Engineering documentation](docs/engineering.md) ｜ 📘 [Full reference](docs/reference.md)
 
 </div>
+<!-- repo-state:begin (generated; do not edit) -->
+<p align="center"><sub>generation: <code>105f91d</code> (2026-08-25T16:04:43Z) · verify: <a href="https://api.github.com/repos/caty-ai/family-os/commits/feat/repo-state-caller-131">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<!-- repo-state:end -->
 
 - [Does any of this sound familiar?](#problems)
 - [Grow it, don't rebuild it](#why)

--- a/README.th.md
+++ b/README.th.md
@@ -26,6 +26,9 @@ Family OS คือแผนที่ที่บอกว่ากลไกซ�
 🔧 [เอกสารสำหรับวิศวกร](docs/engineering.md) (ภาษาอังกฤษ) ｜ 📘 [ข้อกำหนดฉบับเต็ม](docs/reference.md) (ภาษาอังกฤษ)
 
 </div>
+<!-- repo-state:begin (generated; do not edit) -->
+<p align="center"><sub>generation: <code>105f91d</code> (2026-08-25T16:04:43Z) · verify: <a href="https://api.github.com/repos/caty-ai/family-os/commits/feat/repo-state-caller-131">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<!-- repo-state:end -->
 
 - [คุณเคยเจอเรื่องแบบนี้ไหม](#problems)
 - [ไม่ใช่สร้างใหม่ แต่คือเลี้ยงให้โต](#why)

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,6 +26,9 @@ Family OS 是一张地图，告诉你解决每一个问题的部件**在哪里**
 🔧 [面向工程师的文档](docs/engineering.md)（英文） ｜ 📘 [详细规格](docs/reference.md)（英文）
 
 </div>
+<!-- repo-state:begin (generated; do not edit) -->
+<p align="center"><sub>generation: <code>105f91d</code> (2026-08-25T16:04:43Z) · verify: <a href="https://api.github.com/repos/caty-ai/family-os/commits/feat/repo-state-caller-131">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>
+<!-- repo-state:end -->
 
 - [你是否也遇到过这些情况？](#problems)
 - [不是重做，而是养成](#why)

--- a/status.json
+++ b/status.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/caty-ai/family-os/main/docs/repo-state/status.schema.json",
+  "schema_version": 1,
+  "generator_version": "repo-state-gen v1",
+  "repo": "caty-ai/family-os",
+  "stamp_mode": "auto",
+  "generated_at": "2026-08-25T16:04:43Z",
+  "describes_commit": "105f91d76f67e4bf43ba5f11c33d1abe37ceb7fe",
+  "describes_commit_date": "2026-08-25T16:04:43Z",
+  "branch": "feat/repo-state-caller-131",
+  "latest_tag": null,
+  "latest_release_url": null,
+  "agents_entry": "FOR-AGENTS.md",
+  "canonical_api": "https://api.github.com/repos/caty-ai/family-os/commits/feat/repo-state-caller-131",
+  "canonical_raw": "https://raw.githubusercontent.com/caty-ai/family-os/105f91d76f67e4bf43ba5f11c33d1abe37ceb7fe/status.json",
+  "freshness_contract": "SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'."
+}


### PR DESCRIPTION
## Why

Pilot of the org-wide repo-state rollout (parent #127). Closes #131.

## What

- `.github/workflows/repo-state-caller.yml` (new, 22 lines): invokes the reusable workflow pinned to `caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.0` with `generator_ref: v0.11.0`, `permissions: contents: write`, `concurrency: group: repo-state-${{ github.ref }}`.
  - Filename differs from the issue's predicted `repo-state.yml` because in family-os that name IS the reusable workflow; one file cannot be both caller and callee (a push trigger would leave `inputs.generator_ref` empty). Declared in the WIP comment on #131.
- Initial stamp by `tools/repo-state-gen.sh` (v0.11.0, this repo's HEAD): stamp blocks in `README.md` / `README.ja.md` / `README.th.md` / `README.zh.md` / `FOR-AGENTS.md` + new `status.json`.

## Verification (local, 2026-08-25)

- `tools/repo-state-gen.sh --check` → `repo-state: check ok`
- Two consecutive `--stamp-mode auto` runs → byte-identical (shasum -c OK on all 6 managed files)
- status.json schema fields present; `stamp_mode: auto`; `agents_entry: FOR-AGENTS.md`
- Note: `branch` in the committed status.json names the PR branch; the post-merge push event triggers the update job, which restamps with `branch: main` (self-healing by design; PR check job performs no freshness comparison).

## File set vs declaration

Diff touches exactly: repo-state-caller.yml, status.json, README*.md ×4, FOR-AGENTS.md — matches the WIP declaration on #131 (54 added / 0 deleted).

## Gate

- Touches `.github/workflows/**` → owner `risk-reviewed` label required (batched org-wide, parent #127).
- Mode decision pending owner: main ruleset `require-review-for-external` has no Integration bypass, so `github-actions[bot]` direct push to main is blocked as-is → owner picks: add scoped bot allowance (preferred per spec §4) or record `verify-only` exception (spec §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## L1-7 completion record (merge-time, 2026-08-27 JST)

- **Candidate SHA**: `572114a` (= PR head at merge: pilot content `04e715d` [3-seat GO] + v0.12.1 bump commit [Grok delta seat GO 8/8 batch; owner re-applied risk-reviewed for this head]).
- **Done when** (issue #131):
  1. Caller pinned with contents:write + concurrency — **PASS** (pilot panel; bump keeps the reviewed shape, now `@v0.12.1` + `secrets: inherit` per canon example).
  2. Initial stamp in all root README*.md ×4 + FOR-AGENTS.md + status.json — **PASS** (pilot panel 3/3: placement after `</div>`/H1, single marker pair per file, two-run byte-identity, `--check` ok). Stamp values describe the pilot-era base; the post-merge app-authenticated update run self-heals to current main (mechanism live-proven on sitter and 7 rollout repos: branch→main, bot stamp HEAD).
  3. `--check` green / byte-identity / above the fold — **PASS** (pilot panel + PR check job green at both heads).
- **Review**: pilot 3-seat blind panel (Codex Sol / Grok 4.6 / GLM 5.3 — all GO at `04e715d`; record PR comment-5413816114); v0.12.1 bump = single heterogeneous delta seat Grok GO 8/8 (owner-approved scheme; family-os row verified from-v0.11.0 variant). Mode decision history and app mechanism: #140 / PR #141 (3-seat GO + live verification).
- **File set vs diff**: `.github/workflows/repo-state-caller.yml` (name deviation from issue prediction declared in WIP), `README*.md` ×4 (stamp only), `FOR-AGENTS.md` (stamp only), `status.json` — matches the WIP declaration on #131.
- **Identities**: writer = Alpha (deterministic generator output + reviewed template, non-code lane), commits as shojikumaru noreply; reviewers as above.
- **CI**: all green incl. risk-review-gate (owner re-applied label for head `572114a`, 2026-08-27 JST).
- **release**: v0.12.2 (this merge; annotated tag + release-sync auto Release). **previous release**: v0.12.1.
