### PR TITLE
repo-state: make the agents entry optional when neither file exists (v0.11.1)

### DIFF
--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -107,7 +107,11 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add -- status.json 'README*.md' "$agents_entry"
+          if [ "$agents_entry" = null ]; then
+            git add -- status.json 'README*.md'
+          else
+            git add -- status.json 'README*.md' "$agents_entry"
+          fi
           git commit -m "chore(repo-state): $short_sha"
 
           if git push origin "HEAD:$TARGET_BRANCH"; then
@@ -125,7 +129,11 @@ jobs:
           agents_entry=$(jq -r '.agents_entry' status.json)
           describes_commit=$(jq -r '.describes_commit' status.json)
           short_sha=$(printf '%s' "$describes_commit" | cut -c1-7)
-          git add -- status.json 'README*.md' "$agents_entry"
+          if [ "$agents_entry" = null ]; then
+            git add -- status.json 'README*.md'
+          else
+            git add -- status.json 'README*.md' "$agents_entry"
+          fi
           git commit -m "chore(repo-state): $short_sha"
           git push origin "HEAD:$TARGET_BRANCH"
 

--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -18,9 +18,13 @@ name: repository state
 #   cancel-in-progress: false
 # jobs:
 #   repo-state:
-#     uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.0
+#     uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.1
 #     with:
-#       generator_ref: v0.11.0
+#       generator_ref: v0.11.1
+#
+# The `uses:` ref and `generator_ref` must always move together: a v0.11.0
+# workflow with a v0.11.1 generator fails at `git add` on a repository whose
+# agents entry is null.
 
 on:
   workflow_call:

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -11,7 +11,10 @@ The stamped-file set is exactly:
 
 1. every existing `README*.md` at the repository root, including every locale; and
 2. the file named by `agents_entry`: either `FOR-AGENTS.md` or `AGENTS.md`, according to
-   which file the repository has.
+   which file the repository has, when present.
+
+When the repository has neither agents entry file, the stamped-file set contains only
+the root `README*.md` files and `agents_entry` is `null`.
 
 Each stamped file contains exactly one block with these marker comments:
 
@@ -49,7 +52,7 @@ Its schema is [`status.schema.json`](./status.schema.json). Field semantics are:
 | `branch` | Branch whose API HEAD is the comparison target, normally the default branch. |
 | `latest_tag` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, and it is refreshed from GitHub only during an explicit release refresh. |
 | `latest_release_url` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, maps to `null` on an explicit GitHub 404 during release refresh, and any other refresh failure is fatal. |
-| `agents_entry` | The stamped agent entry file, exactly `FOR-AGENTS.md` or `AGENTS.md`. |
+| `agents_entry` | The stamped agent entry file, exactly `FOR-AGENTS.md` or `AGENTS.md`, or `null` when the repository has neither file. |
 | `canonical_api` | CDN-independent GitHub commits API URL for `repo` and `branch`. |
 | `canonical_raw` | Immutable raw URL for `status.json` at `describes_commit`. |
 | `freshness_contract` | Exactly `SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'.` |

--- a/docs/repo-state/status.schema.json
+++ b/docs/repo-state/status.schema.json
@@ -63,8 +63,8 @@
       "format": "uri"
     },
     "agents_entry": {
-      "type": "string",
-      "enum": ["FOR-AGENTS.md", "AGENTS.md"]
+      "type": ["string", "null"],
+      "enum": ["FOR-AGENTS.md", "AGENTS.md", null]
     },
     "canonical_api": {
       "type": "string",

--- a/tools/repo-state-gen.sh
+++ b/tools/repo-state-gen.sh
@@ -72,7 +72,7 @@ resolve_agents_entry() {
     elif [ -f AGENTS.md ]; then
         printf '%s\n' AGENTS.md
     else
-        fail "neither FOR-AGENTS.md nor AGENTS.md exists"
+        :
     fi
 }
 
@@ -83,7 +83,9 @@ for readme_file in README*.md; do
 done | LC_ALL=C sort > "$tmp_root/readmes"
 [ -s "$tmp_root/readmes" ] || fail "no root README*.md files found"
 cp "$tmp_root/readmes" "$tmp_root/targets"
-printf '%s\n' "$agents_entry" >> "$tmp_root/targets"
+if [ -n "$agents_entry" ]; then
+    printf '%s\n' "$agents_entry" >> "$tmp_root/targets"
+fi
 
 marker_state() {
     awk '
@@ -193,7 +195,8 @@ validate_status() {
           (.latest_tag | type == "string" and length > 0)) and
         ((has("latest_release_url") | not) or .latest_release_url == null or
           (.latest_release_url | type == "string" and test("^https://github[.]com/"))) and
-        (.agents_entry == "FOR-AGENTS.md" or .agents_entry == "AGENTS.md") and
+        (.agents_entry == "FOR-AGENTS.md" or .agents_entry == "AGENTS.md" or
+          .agents_entry == null) and
         (.canonical_api | type == "string") and
         (.canonical_raw | type == "string") and
         .freshness_contract == $freshness
@@ -205,7 +208,7 @@ validate_status() {
     status_branch=$(jq -r '.branch' status.json)
     status_sha=$(jq -r '.describes_commit' status.json)
     status_time=$(jq -r '.generated_at' status.json)
-    status_agents=$(jq -r '.agents_entry' status.json)
+    status_agents=$(jq -r '.agents_entry // ""' status.json)
     status_api=$(jq -r '.canonical_api' status.json)
     status_raw=$(jq -r '.canonical_raw' status.json)
     expected_api="https://api.github.com/repos/$status_repo/commits/$status_branch"
@@ -402,6 +405,11 @@ if [ -n "$latest_release_url" ]; then
 else
     latest_release_url_json=null
 fi
+if [ -n "$agents_entry" ]; then
+    agents_entry_json="\"$agents_entry\""
+else
+    agents_entry_json=null
+fi
 
 cat > "$tmp_root/status.json" <<EOF
 {
@@ -416,7 +424,7 @@ cat > "$tmp_root/status.json" <<EOF
   "branch": "$branch_json",
   "latest_tag": $latest_tag_json,
   "latest_release_url": $latest_release_url_json,
-  "agents_entry": "$agents_entry",
+  "agents_entry": $agents_entry_json,
   "canonical_api": "$canonical_api",
   "canonical_raw": "$canonical_raw",
   "freshness_contract": "$FRESHNESS_CONTRACT"

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -31,7 +31,7 @@ assert_eq() {
 }
 
 new_repo() {
-    local agents_file=$1
+    local agents_file=${1-}
     local repo
     repo=$(mktemp -d "$TEST_TMP/repo.XXXXXX")
     git -C "$repo" init -q -b main
@@ -61,11 +61,13 @@ EOF
 
 Thai introduction.
 EOF
-    cat > "$repo/$agents_file" <<'EOF'
+    if [[ -n "$agents_file" ]]; then
+        cat > "$repo/$agents_file" <<'EOF'
 # Agent guide
 
 Route: read the repository guide first.
 EOF
+    fi
 
     git -C "$repo" add .
     GIT_AUTHOR_DATE=2026-08-25T01:02:03Z \
@@ -204,6 +206,39 @@ test_agents_resolution() {
     assert_eq FOR-AGENTS.md "$(jq -r '.agents_entry' "$repo/status.json")" 'FOR-AGENTS.md was not resolved'
     [[ -f "$repo/FOR-AGENTS.md" && ! -e "$repo/AGENTS.md" ]] || fail 'FOR-AGENTS.md fixture was altered incorrectly'
     printf '%s\n' 'agents entry resolution: ok'
+}
+
+test_no_agents_entry() {
+    local repo first second file
+    repo=$(new_repo)
+    run_gen "$repo" > /dev/null
+    jq -e '.agents_entry == null' "$repo/status.json" > /dev/null \
+        || fail 'no-agents fixture did not record agents_entry as null'
+    for file in README.md README.ja.md README.zh.md README.th.md; do
+        [[ $(grep -c '<!-- repo-state:begin' "$repo/$file") -eq 1 ]] \
+            || fail "$file was not stamped exactly once in the no-agents fixture"
+    done
+    [[ ! -e "$repo/AGENTS.md" && ! -e "$repo/FOR-AGENTS.md" ]] \
+        || fail 'no-agents fixture unexpectedly gained an agents entry file'
+
+    first=$(managed_digest "$repo")
+    run_gen "$repo" > /dev/null
+    second=$(managed_digest "$repo")
+    assert_eq "$first" "$second" 'two no-agents generator runs were not byte-identical'
+    run_gen "$repo" --check > /dev/null
+
+    cp "$repo/README.ja.md" "$repo/AGENTS.md"
+    expect_fail '--check accepted agents_entry null after AGENTS.md was added' run_gen "$repo" --check
+    grep -q 'status.json agents_entry does not match the repository' "$TEST_TMP/expected-failure.err" \
+        || fail 'null-to-file agents-entry mismatch error was unclear'
+
+    rm "$repo/AGENTS.md"
+    jq '.agents_entry = "AGENTS.md"' "$repo/status.json" > "$repo/status.json.tmp"
+    mv "$repo/status.json.tmp" "$repo/status.json"
+    expect_fail '--check accepted an agents_entry naming a missing AGENTS.md' run_gen "$repo" --check
+    grep -q 'status.json agents_entry does not match the repository' "$TEST_TMP/expected-failure.err" \
+        || fail 'file-to-null agents-entry mismatch error was unclear'
+    printf '%s\n' 'no agents entry: null, deterministic, and mismatch-safe'
 }
 
 test_github_repository_precedence() {
@@ -535,6 +570,7 @@ test_marker_idempotency
 test_chained_stamp_walk
 test_four_locale_set
 test_agents_resolution
+test_no_agents_entry
 test_github_repository_precedence
 test_agents_entry_conflict
 test_anchorless_readme_error


### PR DESCRIPTION
## Why

Closes #133. Rollout blocker for parent #127: v0.11.0's generator hard-fails on repos with no root `AGENTS.md`/`FOR-AGENTS.md` — 7 of the 12 rollout repos (measured via contents API 2026-08-25). Child issues define the entry as stamped "if present"; the generator now matches that contract. Chosen over per-repo stub AGENTS.md files (would overlap the #106 content-design lane and exceed "stamp block only" scope).

## What (68 added / 13 deleted; matches WIP declaration on #133)

- `tools/repo-state-gen.sh`: `resolve_agents_entry` returns empty on the neither-case (both-files stays a hard error); targets/stamp set skip it; `status.json` gets `agents_entry: null`; `--check` accepts the tri-state and fails BOTH mismatch directions (file exists but status null / status names a missing file).
- `.github/workflows/repo-state.yml`: null guard around `git add ... "$agents_entry"` in both push paths — `git add null` can never happen.
- `docs/repo-state/status.schema.json`: `agents_entry` → `["string","null"]` with null in the enum.
- `docs/repo-state/spec.md`: §1/§2 document the null case.
- `tools/selftest_repo_state_gen.sh`: new fixture coverage — no-entry repo (generate, null, determinism, --check ok) + both mismatch failure cases; all existing cases unchanged.

## Verification (writer=Codex GPT-5.6 Sol self-verify + Alpha independent re-run, 2026-08-25)

- `bash tools/selftest_repo_state_gen.sh` → ok (incl. "no agents entry: null, deterministic, and mismatch-safe")
- `make test` → all selftests green
- `sh -n` clean; POSIX sh preserved
- README-only fixture: two-run byte-identity (shasum equal), `--check` ok, `agents_entry: null`
- FOR-AGENTS.md regression fixture: managed files byte-identical to v0.11.0 output

## Release

Ship as `v0.11.1` (annotated tag; release-sync auto-generates the GitHub Release from the tag push — no manual `gh release create`). Rollout callers will pin `v0.11.1`.

## Gate

Touches `.github/workflows/**` → owner `risk-reviewed` label required (batched with the #127 clicks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## L1-7 completion record (merge-time, 2026-08-26)

- **Candidate SHA**: `09c3227e0b102e5ae2d394f5bb8b4dd3e4a23ee9` (= PR head at merge; 3-seat cumulative GO bound to this SHA)
- **Done when** (issue #133):
  1. Selftest green incl. new no-agents cases, existing untouched — **PASS**. Evidence: `bash tools/selftest_repo_state_gen.sh` → `selftest_repo_state_gen: ok` (writer self-verify + Alpha independent re-run 2026-08-25 + all 3 seats ran it from copies; Kimi/GLM verified existing assertions unweakened via diff).
  2. No-agents fixture: two runs byte-identical, `--check` ok, `agents_entry: null` — **PASS**. Evidence: writer fixture (shasum pair identical, `repo-state: check ok`, `jq .agents_entry` → null) + independent fixtures by Kimi (sh+dash), GLM (git init README-only), Opus (fx/a, unquoted JSON null confirmed via od).
  3. Repo WITH FOR-AGENTS.md byte-identical to v0.11.0 — **PASS**. Evidence: all 3 seats reconstructed the v0.11.0 generator by reverse-applying the diff and compared outputs on identical fixtures: `cmp`/`diff -r` empty (Kimi/GLM/Opus independently).
  4. Both mismatch directions fail `--check` — **PASS**. Evidence: Dir A (entry file exists, status null) and Dir B (status names missing file) → `status.json agents_entry does not match the repository`, exit 1 (3 seats, own fixtures).
  5. v0.11.1 annotated tag + GitHub Release — **executed at this merge**: tag on the merge commit; Release auto-generated by release-sync from the tag push (no manual `gh release create`).
- **File set vs diff**: `tools/repo-state-gen.sh`, `tools/selftest_repo_state_gen.sh`, `docs/repo-state/status.schema.json`, `docs/repo-state/spec.md`, `.github/workflows/repo-state.yml` — matches the WIP declaration on #133 exactly (delta commit `09c3227` touched only the declared workflow file's comment block).
- **Identities**: writer = Codex GPT-5.6 Sol (via sitter-run, briefs archived in session scratchpad); reviewers = Kimi K3 / GLM 5.3 / Opus 5 (fresh-context, read-only, blind, writer-disjoint; requested=actual); integrator = Alpha (Claude Fable 5), commits as shojikumaru noreply.
- **Review records**: #133 issuecomment-5413742834 (round 1 + delta confirmation).
- **CI**: all checks green incl. risk-review-gate (owner `risk-reviewed` label 2026-08-26).
- **release**: v0.11.1 (this merge). **previous release**: v0.11.0.
