### PR TITLE
repo-state: weekly audit — identity invariant, regenerate-and-diff, caller check, heartbeat (#134)

### DIFF
--- a/.github/workflows/family-links.yml
+++ b/.github/workflows/family-links.yml
@@ -79,7 +79,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           python3 -B tools/repo_state_audit.py
-          ${{ github.event_name == 'schedule' && '--require-reality' || '' }}
+          ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '--require-reality' || '' }}
           --report-file "$RUNNER_TEMP/repo-state-audit.txt"
 
       - name: expose heartbeat lines to the report job
@@ -399,15 +399,17 @@ jobs:
     name: open an issue if the scheduled run failed
     runs-on: ubuntu-latest
     needs: [registry, repo-state-audit, family-footer, publication-gate, links, evidence-freshness]
-    if: always() && github.event_name == 'schedule'
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
       # Both labels (stale-pointer and severity:high) are assumed to exist;
       # do not delete them from the repository.
+      # Manual dispatch reports heartbeat only; failure issues remain schedule-only.
       - name: file a stale-pointer issue
-        if: contains(needs.*.result, 'failure')
+        if: github.event_name == 'schedule' && contains(needs.*.result, 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO_STATE_AUDIT_RESULT: ${{ needs.repo-state-audit.result }}
         run: |
           existing_issue="$(gh issue list \
             --repo "${{ github.repository }}" \
@@ -417,10 +419,25 @@ jobs:
             --jq '[.[] | select(.title | startswith("Weekly check failed"))][0].number // empty')"
 
           if [ -n "$existing_issue" ]; then
-            gh issue comment "$existing_issue" \
-              --repo "${{ github.repository }}" \
-              --body "Another weekly family-links run failed: $RUN_URL"
+            if [ "$REPO_STATE_AUDIT_RESULT" = 'failure' ]; then
+              gh issue comment "$existing_issue" \
+                --repo "${{ github.repository }}" \
+                --body "Another weekly family-links run failed: $RUN_URL
+
+          The repo-state-audit job failed; inspect the linked run."
+            else
+              gh issue comment "$existing_issue" \
+                --repo "${{ github.repository }}" \
+                --body "Another weekly family-links run failed: $RUN_URL"
+            fi
             exit 0
+          fi
+
+          repo_state_note=''
+          if [ "$REPO_STATE_AUDIT_RESULT" = 'failure' ]; then
+            repo_state_note='
+
+          The repo-state-audit job failed; inspect the linked run.'
           fi
 
           gh issue create \
@@ -439,10 +456,10 @@ jobs:
 
           Run: $RUN_URL
 
-          To fix: update \`registry/modules.json\`, run \`python3 -B tools/render.py\`, and commit."
+          To fix: update \`registry/modules.json\`, run \`python3 -B tools/render.py\`, and commit.$repo_state_note"
 
-      - name: append successful repo-state heartbeat
-        if: needs.repo-state-audit.result == 'success'
+      - name: append repo-state heartbeat
+        if: needs.repo-state-audit.result != 'skipped' && needs.repo-state-audit.outputs.report_b64 != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPORT_B64: ${{ needs.repo-state-audit.outputs.report_b64 }}
@@ -452,7 +469,7 @@ jobs:
           report_title='Weekly repo-state audit heartbeat'
           report_lines="$(printf '%s' "$REPORT_B64" | base64 --decode)"
           [ -n "$report_lines" ] || {
-            echo 'repo-state audit succeeded without heartbeat lines' >&2
+            echo 'repo-state audit completed without heartbeat lines' >&2
             exit 1
           }
 

--- a/.github/workflows/family-links.yml
+++ b/.github/workflows/family-links.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   issues: write
 
 jobs:
@@ -60,6 +61,37 @@ jobs:
 
       - name: check generated blocks are up to date
         run: python3 -B tools/render.py --check
+
+  repo-state-audit:
+    name: repo-state audit
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      report_b64: ${{ steps.report-lines.outputs.report_b64 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: selftest repo-state audit
+        run: python3 -B tools/selftest_repo_state_audit.py
+
+      - name: audit every public repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          python3 -B tools/repo_state_audit.py
+          ${{ github.event_name == 'schedule' && '--require-reality' || '' }}
+          --report-file "$RUNNER_TEMP/repo-state-audit.txt"
+
+      - name: expose heartbeat lines to the report job
+        id: report-lines
+        if: always()
+        run: |
+          if [ -s "$RUNNER_TEMP/repo-state-audit.txt" ]; then
+            report_b64="$(base64 < "$RUNNER_TEMP/repo-state-audit.txt" | tr -d '\n')"
+            echo "report_b64=$report_b64" >> "$GITHUB_OUTPUT"
+          else
+            echo "report_b64=" >> "$GITHUB_OUTPUT"
+          fi
 
   family-footer:
     name: family footer
@@ -366,12 +398,13 @@ jobs:
   report:
     name: open an issue if the scheduled run failed
     runs-on: ubuntu-latest
-    needs: [registry, family-footer, publication-gate, links, evidence-freshness]
-    if: failure() && github.event_name == 'schedule'
+    needs: [registry, repo-state-audit, family-footer, publication-gate, links, evidence-freshness]
+    if: always() && github.event_name == 'schedule'
     steps:
       # Both labels (stale-pointer and severity:high) are assumed to exist;
       # do not delete them from the repository.
       - name: file a stale-pointer issue
+        if: contains(needs.*.result, 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -407,3 +440,41 @@ jobs:
           Run: $RUN_URL
 
           To fix: update \`registry/modules.json\`, run \`python3 -B tools/render.py\`, and commit."
+
+      - name: append successful repo-state heartbeat
+        if: needs.repo-state-audit.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT_B64: ${{ needs.repo-state-audit.outputs.report_b64 }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -eu
+          report_title='Weekly repo-state audit heartbeat'
+          report_lines="$(printf '%s' "$REPORT_B64" | base64 --decode)"
+          [ -n "$report_lines" ] || {
+            echo 'repo-state audit succeeded without heartbeat lines' >&2
+            exit 1
+          }
+
+          existing_issue="$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label stale-pointer \
+            --json number,title \
+            --jq '[.[] | select(.title == "Weekly repo-state audit heartbeat")][0].number // empty')"
+
+          if [ -z "$existing_issue" ]; then
+            created_url="$(gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$report_title" \
+              --label stale-pointer \
+              --body 'Standing weekly heartbeat for the repository-state audit. Dated per-repository results are appended as comments.')"
+            existing_issue=${created_url##*/}
+          fi
+
+          comment_file="$RUNNER_TEMP/repo-state-heartbeat.md"
+          printf 'Repo-state audit completed.\n\n%s\n\nRun: %s\n' \
+            "$report_lines" "$RUN_URL" > "$comment_file"
+          gh issue comment "$existing_issue" \
+            --repo "${{ github.repository }}" \
+            --body-file "$comment_file"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # checks — the scripts themselves are canonical; do not add logic here.
 test:
 	bash tools/selftest_repo_state_gen.sh
+	python3 -B tools/selftest_repo_state_audit.py
 	python3 -B tools/selftest_check_registry.py
 	python3 -B tools/selftest_family_footer.py
 	python3 -B tools/check_publication_gate.py --selftest

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -115,7 +115,8 @@ fails closed when reality cannot be enumerated. It verifies schema presence, app
 mode-specific health invariant by commit identity, regenerates and diffs the managed
 state, checks the latest caller-run conclusion, and appends dated results to the weekly
 report issue. An external schedule-liveness probe treats a report older than eight days
-as an alert, including GitHub's scheduled-workflow auto-disable failure mode.
+as an alert, including GitHub's scheduled-workflow auto-disable failure mode. A TRANSIENT
+content-commit HEAD escalates to FAIL after it remains unstamped for seven days.
 
 For `auto`, audit health means HEAD is a bot stamp commit and `describes_commit` is its
 nearest non-stamp ancestor; position alone is insufficient. The automatic mechanism

--- a/tools/repo_state_audit.py
+++ b/tools/repo_state_audit.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""Audit repository-state stamps across every public repository in the org.
+
+The org universe is deliberately enumerated without authentication.  The
+Actions sub-check is the one exception: GitHub does not expose workflow state
+reliably to anonymous callers, so it uses GH_TOKEN/GITHUB_TOKEN when present.
+
+Python 3.9+, standard library only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from check_registry import fetch_org_repos
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_REGISTRY = REPO_ROOT / "registry" / "modules.json"
+DEFAULT_SCHEMA = REPO_ROOT / "docs" / "repo-state" / "status.schema.json"
+DEFAULT_GENERATOR = REPO_ROOT / "tools" / "repo-state-gen.sh"
+
+REPOSITORY_PATH = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+STAMP_PREFIX = "chore(repo-state):"
+BOT_COMMITTER = "github-actions[bot]"
+TRANSIENT_MAX_AGE = datetime.timedelta(days=7)
+BEGIN_MARKER = "<!-- repo-state:begin (generated; do not edit) -->"
+END_MARKER = "<!-- repo-state:end -->"
+
+STATUS_ORDER = {"PASS": 0, "UNKNOWN": 1, "TRANSIENT": 2, "FAIL": 3}
+SUPPORTED_SCHEMA_KEYWORDS = {
+    "$id",
+    "$schema",
+    "additionalProperties",
+    "const",
+    "description",
+    "enum",
+    "format",
+    "minLength",
+    "pattern",
+    "properties",
+    "required",
+    "title",
+    "type",
+}
+
+
+class AuditError(Exception):
+    """A known audit-contract failure."""
+
+
+@dataclasses.dataclass(frozen=True)
+class CommitIdentity:
+    sha: str
+    parents: Tuple[str, ...]
+    committer: str
+    committed_at: datetime.datetime
+    message: str
+
+    @property
+    def is_stamp_message(self) -> bool:
+        return self.message.startswith(STAMP_PREFIX)
+
+
+@dataclasses.dataclass(frozen=True)
+class Check:
+    status: str
+    detail: str
+
+
+@dataclasses.dataclass(frozen=True)
+class RepoResult:
+    repo: str
+    status: str
+    details: Tuple[str, ...]
+
+
+def run_git(repo_dir: pathlib.Path, *args: str) -> str:
+    command = ["git", "-C", str(repo_dir)] + list(args)
+    completed = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise AuditError("git %s failed" % " ".join(args))
+    return completed.stdout.rstrip("\n")
+
+
+def read_commit(repo_dir: pathlib.Path, revision: str) -> CommitIdentity:
+    output = run_git(
+        repo_dir,
+        "show",
+        "-s",
+        "--format=%H%x00%P%x00%cn%x00%cI%x00%B",
+        revision,
+    )
+    fields = output.split("\x00", 4)
+    if len(fields) != 5:
+        raise AuditError("could not parse commit identity for %s" % revision)
+    sha, raw_parents, committer, committed_at, message = fields
+    parents = tuple(raw_parents.split()) if raw_parents else ()
+    try:
+        timestamp = datetime.datetime.fromisoformat(committed_at.replace("Z", "+00:00"))
+    except ValueError:
+        raise AuditError("could not parse commit date for %s" % revision)
+    return CommitIdentity(sha, parents, committer, timestamp, message.rstrip("\n"))
+
+
+def nearest_non_stamp_ancestor(repo_dir: pathlib.Path, revision: str) -> str:
+    """Walk the first-parent stamp chain until commit identity is content."""
+    current = read_commit(repo_dir, revision)
+    while current.is_stamp_message:
+        if len(current.parents) != 1:
+            raise AuditError(
+                "stamp commit %s must have exactly one parent" % current.sha
+            )
+        current = read_commit(repo_dir, current.parents[0])
+    return current.sha
+
+
+def classify_identity(
+    repo_dir: pathlib.Path,
+    status: dict,
+    now: Optional[datetime.datetime] = None,
+) -> Check:
+    mode = status.get("stamp_mode")
+    described = status.get("describes_commit")
+    head = read_commit(repo_dir, "HEAD")
+
+    if mode == "auto":
+        if not head.is_stamp_message:
+            current_time = now or datetime.datetime.now(datetime.timezone.utc)
+            age = current_time - head.committed_at.astimezone(datetime.timezone.utc)
+            if age >= TRANSIENT_MAX_AGE:
+                return Check(
+                    "FAIL",
+                    "HEAD has remained an unstamped content commit for at least 7 days",
+                )
+            return Check(
+                "TRANSIENT",
+                "HEAD is a content commit; the automatic stamp may still be pending",
+            )
+        if head.committer != BOT_COMMITTER:
+            return Check(
+                "FAIL",
+                "HEAD has a stamp message but committer is not github-actions[bot]",
+            )
+        expected = nearest_non_stamp_ancestor(repo_dir, head.sha)
+        if described != expected:
+            return Check(
+                "FAIL",
+                "auto stamp describes %s, nearest non-stamp ancestor is %s"
+                % (str(described)[:12], expected[:12]),
+            )
+        return Check("PASS", "auto identity invariant holds")
+
+    if mode == "verify-only":
+        if head.is_stamp_message:
+            return Check(
+                "FAIL",
+                "verify-only HEAD must be the merged content commit, not a stamp commit",
+            )
+        if not head.parents:
+            return Check("FAIL", "verify-only HEAD has no base-branch parent lineage")
+        expected = nearest_non_stamp_ancestor(repo_dir, head.parents[0])
+        if described != expected:
+            return Check(
+                "FAIL",
+                "verify-only stamp describes %s, base HEAD^ lineage resolves to %s"
+                % (str(described)[:12], expected[:12]),
+            )
+        return Check("PASS", "verify-only base HEAD^ identity invariant holds")
+
+    return Check("FAIL", "unknown stamp_mode %r" % mode)
+
+
+def _json_type_matches(value, expected: str) -> bool:
+    if expected == "null":
+        return value is None
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    return False
+
+
+def _valid_datetime(value: str) -> bool:
+    try:
+        datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return "T" in value and (
+        value.endswith("Z") or re.search(r"[+-][0-9]{2}:[0-9]{2}$", value) is not None
+    )
+
+
+def _valid_uri(value: str) -> bool:
+    parsed = urllib.parse.urlsplit(value)
+    return bool(parsed.scheme and parsed.netloc)
+
+
+def _validate_node(value, schema: dict, path: str, errors: List[str]) -> None:
+    # Issue #133 makes agents_entry nullable.  Accept both the v0.11 schema and
+    # that forward-compatible representation while the sibling lane lands.
+    if path == "$.agents_entry" and value is None:
+        return
+
+    expected_types = schema.get("type")
+    if expected_types is not None:
+        if isinstance(expected_types, str):
+            expected_types = [expected_types]
+        if not any(_json_type_matches(value, item) for item in expected_types):
+            errors.append("%s: expected type %s" % (path, " or ".join(expected_types)))
+            return
+
+    if "const" in schema and value != schema["const"]:
+        errors.append("%s: does not match the schema constant" % path)
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append("%s: is not one of the allowed values" % path)
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for field in required:
+            if field not in value:
+                errors.append("%s.%s: required property is missing" % (path, field))
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            for field in value:
+                if field not in properties:
+                    errors.append("%s.%s: additional property is not allowed" % (path, field))
+        for field, child in properties.items():
+            if field in value:
+                _validate_node(value[field], child, "%s.%s" % (path, field), errors)
+
+    if isinstance(value, str):
+        minimum = schema.get("minLength")
+        if minimum is not None and len(value) < minimum:
+            errors.append("%s: shorter than minLength %d" % (path, minimum))
+        pattern = schema.get("pattern")
+        if pattern is not None and re.search(pattern, value) is None:
+            errors.append("%s: does not match the required pattern" % path)
+        format_name = schema.get("format")
+        if format_name == "date-time" and not _valid_datetime(value):
+            errors.append("%s: is not a valid date-time" % path)
+        if format_name == "uri" and not _valid_uri(value):
+            errors.append("%s: is not a valid URI" % path)
+
+
+def ensure_supported_schema(schema: dict, path: str = "$") -> None:
+    unknown = sorted(set(schema) - SUPPORTED_SCHEMA_KEYWORDS)
+    if unknown:
+        raise AuditError(
+            "%s uses unsupported schema keywords: %s" % (path, ", ".join(unknown))
+        )
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        raise AuditError("%s.properties must be an object" % path)
+    for field, child in properties.items():
+        if not isinstance(child, dict):
+            raise AuditError("%s.properties.%s must be an object" % (path, field))
+        ensure_supported_schema(child, "%s.properties.%s" % (path, field))
+
+
+def validate_status(status: dict, schema: dict, repo: str) -> List[str]:
+    errors: List[str] = []
+    _validate_node(status, schema, "$", errors)
+    if status.get("repo") != repo:
+        errors.append("$.repo: expected %s" % repo)
+    if status.get("branch") != "main":
+        errors.append("$.branch: weekly audit requires main")
+    if status.get("generated_at") != status.get("describes_commit_date"):
+        errors.append("$.generated_at: must equal describes_commit_date")
+
+    described = status.get("describes_commit")
+    expected_api = "https://api.github.com/repos/%s/commits/main" % repo
+    expected_raw = "https://raw.githubusercontent.com/%s/%s/status.json" % (
+        repo,
+        described,
+    )
+    if status.get("canonical_api") != expected_api:
+        errors.append("$.canonical_api: inconsistent with repo/main")
+    if status.get("canonical_raw") != expected_raw:
+        errors.append("$.canonical_raw: inconsistent with describes_commit")
+    return errors
+
+
+def _expected_block(status: dict) -> List[str]:
+    return [
+        BEGIN_MARKER,
+        '<p align="center"><sub>generation: <code>%s</code> (%s) · verify: '
+        '<a href="%s">API HEAD</a> · <a href="./status.json">status.json</a></sub></p>'
+        % (
+            status["describes_commit"][:7],
+            status["generated_at"],
+            status["canonical_api"],
+        ),
+        END_MARKER,
+    ]
+
+
+def _block_bounds(lines: Sequence[str], path: pathlib.Path) -> Tuple[int, int]:
+    begins = [index for index, line in enumerate(lines) if BEGIN_MARKER in line]
+    ends = [index for index, line in enumerate(lines) if END_MARKER in line]
+    if len(begins) != 1 or len(ends) != 1 or begins[0] >= ends[0]:
+        raise AuditError("%s: missing, duplicate, or malformed stamp markers" % path.name)
+    if lines[begins[0]] != BEGIN_MARKER or lines[ends[0]] != END_MARKER:
+        raise AuditError("%s: stamp markers must occupy exact lines" % path.name)
+    return begins[0], ends[0]
+
+
+def strip_stamp_block(data: bytes, path: pathlib.Path) -> bytes:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise AuditError("%s is not UTF-8: %s" % (path.name, error))
+    lines = text.splitlines(keepends=True)
+    marker_lines = [line.rstrip("\r\n") for line in lines]
+    begin, end = _block_bounds(marker_lines, path)
+    return "".join(lines[:begin] + lines[end + 1 :]).encode("utf-8")
+
+
+def validate_stamp_blocks(repo_dir: pathlib.Path, status: dict) -> List[pathlib.Path]:
+    readmes = sorted(
+        path for path in repo_dir.glob("README*.md") if path.is_file()
+    )
+    if not readmes:
+        raise AuditError("no root README*.md files found")
+    targets = list(readmes)
+    agents_entry = status.get("agents_entry")
+    if agents_entry is None:
+        if (repo_dir / "AGENTS.md").exists() or (repo_dir / "FOR-AGENTS.md").exists():
+            raise AuditError("agents_entry is null but an agent entry file exists")
+    else:
+        agents_path = repo_dir / agents_entry
+        if not agents_path.is_file():
+            raise AuditError("agents_entry file %s is missing" % agents_entry)
+        targets.append(agents_path)
+
+    expected = _expected_block(status)
+    for path in targets:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as error:
+            raise AuditError("could not read %s: %s" % (path.name, error))
+        begin, end = _block_bounds(lines, path)
+        if lines[begin : end + 1] != expected:
+            raise AuditError("%s: stamp block is inconsistent with status.json" % path.name)
+    return targets
+
+
+def _snapshot_paths(
+    repo_dir: pathlib.Path, paths: Iterable[str]
+) -> Dict[str, bytes]:
+    snapshot: Dict[str, bytes] = {}
+    for relative in sorted(set(paths)):
+        path = repo_dir / relative
+        if path.is_file():
+            snapshot[relative] = path.read_bytes()
+    return snapshot
+
+
+def _nul_paths(output: str) -> List[str]:
+    return [path for path in output.split("\x00") if path]
+
+
+def _working_tree_changes(repo_dir: pathlib.Path) -> List[str]:
+    changed = set(_nul_paths(run_git(repo_dir, "diff", "--name-only", "-z", "--")))
+    changed.update(
+        _nul_paths(run_git(repo_dir, "diff", "--cached", "--name-only", "-z", "--"))
+    )
+    changed.update(
+        _nul_paths(run_git(repo_dir, "ls-files", "--others", "--exclude-standard", "-z"))
+    )
+    return sorted(changed)
+
+
+def check_regeneration(
+    repo_dir: pathlib.Path,
+    repo: str,
+    status: dict,
+    generator: pathlib.Path,
+    identity: Check,
+) -> Check:
+    agents_entry = status.get("agents_entry")
+    nullable_without_agents = (
+        agents_entry is None
+        and not (repo_dir / "AGENTS.md").exists()
+        and not (repo_dir / "FOR-AGENTS.md").exists()
+    )
+
+    allowed = {"status.json"}
+    allowed.update(
+        path.name for path in repo_dir.glob("README*.md") if path.is_file()
+    )
+    if agents_entry is not None:
+        allowed.add(agents_entry)
+    before = _snapshot_paths(repo_dir, allowed)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "REPO_STATE_NO_GH": "1",
+            "REPO_STATE_REPO": repo,
+            "REPO_STATE_BRANCH": "main",
+        }
+    )
+    try:
+        completed = subprocess.run(
+            ["sh", str(generator), "--stamp-mode", status["stamp_mode"]],
+            cwd=str(repo_dir),
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError:
+        return Check("FAIL", "canonical generator could not be executed")
+    if completed.returncode != 0:
+        if (
+            nullable_without_agents
+            and "neither FOR-AGENTS.md nor AGENTS.md exists" in completed.stderr
+        ):
+            # v0.11's generator predates nullable agents_entry.  It was still
+            # executed; #133's generator will continue through the normal
+            # regeneration checks once the sibling lane lands.
+            return Check(
+                "PASS", "nullable agents_entry accepted during generator rollout"
+            )
+        return Check("FAIL", "canonical generator failed")
+
+    changed = _working_tree_changes(repo_dir)
+    after = _snapshot_paths(repo_dir, allowed)
+
+    outside = [path for path in changed if path not in allowed]
+    if outside:
+        return Check(
+            "FAIL",
+            "generator changed files outside managed regions: %s" % ", ".join(outside),
+        )
+
+    for relative in changed:
+        if relative == "status.json":
+            continue
+        path = pathlib.Path(relative)
+        if relative not in before or relative not in after:
+            return Check("FAIL", "generator added or removed managed file %s" % relative)
+        try:
+            if strip_stamp_block(before[relative], path) != strip_stamp_block(
+                after[relative], path
+            ):
+                return Check(
+                    "FAIL", "generator changed content outside the stamp block in %s" % relative
+                )
+        except AuditError as error:
+            return Check("FAIL", str(error))
+
+    if not changed:
+        return Check("PASS", "canonical regeneration is byte-clean")
+    if status["stamp_mode"] == "auto" and identity.status == "PASS":
+        return Check(
+            "FAIL",
+            "canonical regeneration changed managed state on a healthy auto stamp",
+        )
+    return Check(
+        "PASS",
+        "canonical regeneration changed only stamp-managed regions (%s)"
+        % ", ".join(changed),
+    )
+
+
+def _http_json(url: str, token: str, timeout: float):
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer %s" % token,
+            "User-Agent": "family-os-repo-state-audit",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.build_opener().open(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise AuditError("Actions API returned HTTP %s" % response.status)
+        return json.loads(response.read().decode("utf-8"))
+
+
+def check_actions(repo: str, token: Optional[str], timeout: float) -> Check:
+    if not token:
+        return Check("UNKNOWN", "caller UNKNOWN(no-token)")
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+    try:
+        payload = _http_json(
+            "https://api.github.com/repos/%s/actions/workflows?per_page=100" % encoded_repo,
+            token,
+            timeout,
+        )
+        workflows = payload.get("workflows") if isinstance(payload, dict) else None
+        if not isinstance(workflows, list):
+            return Check("FAIL", "repo-state caller workflow list is unparseable")
+        if any(not isinstance(workflow, dict) for workflow in workflows):
+            return Check("FAIL", "repo-state caller workflow list is unparseable")
+        total_count = payload.get("total_count")
+        if isinstance(total_count, int) and total_count > len(workflows):
+            return Check("FAIL", "repo-state caller workflow list is truncated")
+
+        exact = [
+            workflow
+            for workflow in workflows
+            if workflow.get("path") == ".github/workflows/repo-state.yml"
+        ]
+        candidates = exact or [
+            workflow
+            for workflow in workflows
+            if "repo-state" in str(workflow.get("path", "")).casefold()
+            or str(workflow.get("name", "")).casefold()
+            in {"repository state", "repo-state"}
+        ]
+        if not candidates:
+            return Check("FAIL", "repo-state caller workflow is missing")
+        if len(candidates) != 1:
+            return Check("FAIL", "repo-state caller workflow is ambiguous")
+        workflow = candidates[0]
+        if workflow.get("state") != "active":
+            return Check(
+                "FAIL",
+                "repo-state caller workflow is %s" % workflow.get("state", "unparseable"),
+            )
+        workflow_id = workflow.get("id")
+        if not isinstance(workflow_id, int):
+            return Check("FAIL", "repo-state caller workflow id is unparseable")
+
+        runs = _http_json(
+            "https://api.github.com/repos/%s/actions/workflows/%d/runs?branch=main&per_page=1"
+            % (encoded_repo, workflow_id),
+            token,
+            timeout,
+        )
+        workflow_runs = runs.get("workflow_runs") if isinstance(runs, dict) else None
+        if not isinstance(workflow_runs, list):
+            return Check("FAIL", "repo-state caller run list is unparseable")
+        if not workflow_runs:
+            return Check("FAIL", "repo-state caller has no main-branch runs")
+        latest = workflow_runs[0]
+        if not isinstance(latest, dict):
+            return Check("FAIL", "latest repo-state caller run is unparseable")
+        run_status = latest.get("status")
+        conclusion = latest.get("conclusion")
+        if run_status != "completed":
+            if not isinstance(run_status, str):
+                return Check("FAIL", "latest repo-state caller status is unparseable")
+            return Check("UNKNOWN", "caller UNKNOWN(%s)" % (run_status or "unparseable"))
+        if conclusion != "success":
+            return Check("FAIL", "latest repo-state caller conclusion is %s" % conclusion)
+        return Check("PASS", "latest repo-state caller conclusion is success")
+    except (
+        AuditError,
+        OSError,
+        urllib.error.URLError,
+        json.JSONDecodeError,
+        UnicodeDecodeError,
+    ):
+        return Check("UNKNOWN", "caller UNKNOWN(api-error)")
+
+
+def _combine(checks: Iterable[Check]) -> Tuple[str, Tuple[str, ...]]:
+    checks = tuple(checks)
+    status = max(checks, key=lambda item: STATUS_ORDER[item.status]).status
+    details = tuple(check.detail for check in checks)
+    return status, details
+
+
+def _load_status(repo_dir: pathlib.Path, schema: dict, repo: str) -> Tuple[dict, List[pathlib.Path]]:
+    path = repo_dir / "status.json"
+    try:
+        raw = path.read_bytes()
+    except OSError as error:
+        raise AuditError("could not read status.json: %s" % error)
+    if len(raw) > 2048:
+        raise AuditError("status.json exceeds 2 KiB")
+    try:
+        status = json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise AuditError("status.json is not valid UTF-8 JSON: %s" % error)
+    if not isinstance(status, dict):
+        raise AuditError("status.json must be a JSON object")
+    errors = validate_status(status, schema, repo)
+    if errors:
+        raise AuditError("status.json invalid: %s" % "; ".join(errors))
+    targets = validate_stamp_blocks(repo_dir, status)
+    return status, targets
+
+
+def audit_checkout(
+    repo: str,
+    repo_dir: pathlib.Path,
+    schema: dict,
+    generator: pathlib.Path,
+    token: Optional[str],
+    timeout: float,
+) -> RepoResult:
+    if not (repo_dir / "status.json").exists():
+        return RepoResult(repo, "PENDING", ("status.json absent (rollout not landed)",))
+    try:
+        status, _targets = _load_status(repo_dir, schema, repo)
+        identity = classify_identity(repo_dir, status)
+        regeneration = check_regeneration(repo_dir, repo, status, generator, identity)
+        actions = check_actions(repo, token, timeout)
+        overall, details = _combine((identity, regeneration, actions))
+        return RepoResult(repo, overall, details)
+    except AuditError as error:
+        return RepoResult(repo, "FAIL", (str(error),))
+
+
+def _clone_main(
+    repo: str, destination: pathlib.Path, timeout: float
+) -> Optional[Check]:
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "--filter=blob:none",
+                "--no-tags",
+                "https://github.com/%s.git" % repo,
+                str(destination),
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return Check("UNKNOWN", "clone unavailable")
+    if completed.returncode != 0:
+        return Check("UNKNOWN", "clone unavailable")
+    try:
+        run_git(destination, "rev-parse", "--verify", "refs/remotes/origin/main")
+        run_git(destination, "checkout", "--quiet", "--detach", "refs/remotes/origin/main")
+    except AuditError:
+        return Check("FAIL", "main branch is missing or cannot be checked out")
+    return None
+
+
+def format_report_line(result: RepoResult, audit_date: str) -> str:
+    details = "; ".join(result.details)
+    return "- %s | %s | %s | %s" % (
+        audit_date,
+        result.repo,
+        result.status,
+        details,
+    )
+
+
+def _load_json(path: pathlib.Path, label: str) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise AuditError("could not load %s: %s" % (label, error))
+    if not isinstance(value, dict):
+        raise AuditError("%s must contain a JSON object" % label)
+    return value
+
+
+def _repositories(args, registry: dict) -> Tuple[Optional[List[str]], Optional[str]]:
+    if args.repo:
+        invalid = [repo for repo in args.repo if REPOSITORY_PATH.fullmatch(repo) is None]
+        if invalid:
+            raise AuditError("invalid --repo value: %s" % invalid[0])
+        return sorted(set(args.repo), key=str.casefold), None
+
+    map_repo = registry.get("map_repo")
+    if not isinstance(map_repo, str) or "/" not in map_repo:
+        raise AuditError("registry map_repo does not identify an organization")
+    org = map_repo.split("/", 1)[0]
+    repos = fetch_org_repos(org, timeout=args.timeout)
+    if repos is None:
+        if args.require_reality:
+            raise AuditError(
+                "could not enumerate org:%s; --require-reality rejects this degraded run"
+                % org
+            )
+        return None, org
+    if not repos:
+        raise AuditError("org:%s enumeration returned an empty universe" % org)
+    return sorted(set(repos), key=str.casefold), None
+
+
+def parse_args(argv: Optional[Sequence[str]] = None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit repo-state status, commit identity, canonical regeneration, "
+            "and latest caller conclusion."
+        )
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        help="audit one owner/repo instead of enumerating the registry organization",
+    )
+    parser.add_argument(
+        "--registry",
+        type=pathlib.Path,
+        default=DEFAULT_REGISTRY,
+        help="registry JSON path (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--schema",
+        type=pathlib.Path,
+        default=DEFAULT_SCHEMA,
+        help="status schema path (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--generator",
+        type=pathlib.Path,
+        default=DEFAULT_GENERATOR,
+        help="canonical generator from this checkout (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--require-reality",
+        action="store_true",
+        help="fail if the public-repository universe cannot be enumerated",
+    )
+    parser.add_argument(
+        "--report-file",
+        type=pathlib.Path,
+        help="also write the dated per-repository lines to this file",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="network/clone timeout in seconds (default: %(default)s)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        registry = _load_json(args.registry, "registry")
+        schema = _load_json(args.schema, "status schema")
+        ensure_supported_schema(schema)
+        if not args.generator.is_file():
+            raise AuditError("canonical generator is missing: %s" % args.generator)
+        repos, degraded_org = _repositories(args, registry)
+    except AuditError as error:
+        print("repo-state audit: error: %s" % error, file=sys.stderr)
+        return 2
+
+    audit_date = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+    if repos is None:
+        lines = [
+            "- %s | org:%s | UNKNOWN | public-repository universe unavailable"
+            % (audit_date, degraded_org)
+        ]
+        results: List[RepoResult] = []
+    else:
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        results = []
+        with tempfile.TemporaryDirectory(prefix="repo-state-audit.") as temporary:
+            temporary_root = pathlib.Path(temporary)
+            for index, repo in enumerate(repos):
+                checkout = temporary_root / ("repo-%03d" % index)
+                clone_problem = _clone_main(repo, checkout, args.timeout)
+                if clone_problem is not None:
+                    results.append(
+                        RepoResult(
+                            repo,
+                            clone_problem.status,
+                            (clone_problem.detail,),
+                        )
+                    )
+                    continue
+                results.append(
+                    audit_checkout(
+                        repo,
+                        checkout,
+                        schema,
+                        args.generator,
+                        token,
+                        args.timeout,
+                    )
+                )
+        lines = [format_report_line(result, audit_date) for result in results]
+
+    for line in lines:
+        print(line)
+    if args.report_file:
+        try:
+            args.report_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        except OSError as error:
+            print("repo-state audit: error: could not write report: %s" % error, file=sys.stderr)
+            return 2
+
+    return 1 if any(result.status == "FAIL" for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo_state_audit.py
+++ b/tools/repo_state_audit.py
@@ -3,7 +3,7 @@
 
 The org universe is deliberately enumerated without authentication.  The
 Actions sub-check is the one exception: GitHub does not expose workflow state
-reliably to anonymous callers, so it uses GH_TOKEN/GITHUB_TOKEN when present.
+reliably to anonymous callers, so it prefers GH_TOKEN/GITHUB_TOKEN when present.
 
 Python 3.9+, standard library only.
 """
@@ -444,11 +444,9 @@ def check_regeneration(
             nullable_without_agents
             and "neither FOR-AGENTS.md nor AGENTS.md exists" in completed.stderr
         ):
-            # v0.11's generator predates nullable agents_entry.  It was still
-            # executed; #133's generator will continue through the normal
-            # regeneration checks once the sibling lane lands.
             return Check(
-                "PASS", "nullable agents_entry accepted during generator rollout"
+                "UNKNOWN",
+                "regeneration skipped: v0.11.0 generator cannot run without an agents entry",
             )
         return Check("FAIL", "canonical generator failed")
 
@@ -492,20 +490,27 @@ def check_regeneration(
     )
 
 
-def _http_json(url: str, token: str, timeout: float):
-    request = urllib.request.Request(
-        url,
-        headers={
+def _http_json(url: str, token: Optional[str], timeout: float):
+    opener = urllib.request.build_opener()
+
+    def fetch(auth_token: Optional[str]):
+        headers = {
             "Accept": "application/vnd.github+json",
-            "Authorization": "Bearer %s" % token,
             "User-Agent": "family-os-repo-state-audit",
             "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
-    with urllib.request.build_opener().open(request, timeout=timeout) as response:
-        if response.status != 200:
-            raise AuditError("Actions API returned HTTP %s" % response.status)
-        return json.loads(response.read().decode("utf-8"))
+        }
+        if auth_token:
+            headers["Authorization"] = "Bearer %s" % auth_token
+        request = urllib.request.Request(url, headers=headers)
+        with opener.open(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    try:
+        return fetch(token)
+    except urllib.error.HTTPError:
+        if not token:
+            raise
+        return fetch(None)
 
 
 def check_actions(repo: str, token: Optional[str], timeout: float) -> Check:
@@ -661,9 +666,12 @@ def _clone_main(
         return Check("UNKNOWN", "clone unavailable")
     try:
         run_git(destination, "rev-parse", "--verify", "refs/remotes/origin/main")
+    except AuditError:
+        return Check("PENDING", "no main branch (empty or non-main default)")
+    try:
         run_git(destination, "checkout", "--quiet", "--detach", "refs/remotes/origin/main")
     except AuditError:
-        return Check("FAIL", "main branch is missing or cannot be checked out")
+        return Check("FAIL", "main branch cannot be checked out")
     return None
 
 
@@ -818,7 +826,23 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             print("repo-state audit: error: could not write report: %s" % error, file=sys.stderr)
             return 2
 
-    return 1 if any(result.status == "FAIL" for result in results) else 0
+    if any(result.status == "FAIL" for result in results):
+        return 1
+    if (
+        args.require_reality
+        and results
+        and all(
+            result.status == "UNKNOWN" and result.details == ("clone unavailable",)
+            for result in results
+        )
+    ):
+        print(
+            "repo-state audit: error: all repositories are clone-unavailable; "
+            "--require-reality rejects this unreachable universe",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
 
 
 if __name__ == "__main__":

--- a/tools/selftest_repo_state_audit.py
+++ b/tools/selftest_repo_state_audit.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Local, network-free self-test for repo_state_audit.py."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import repo_state_audit as audit
+
+
+class RepoFixture:
+    def __init__(self, root: pathlib.Path) -> None:
+        self.root = root
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", str(root)],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.name", "Fixture Author"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.email", "fixture@localhost"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "core.hooksPath", "/dev/null"],
+            check=True,
+        )
+        self.counter = 0
+
+    def commit(self, message: str, committer: str = "Fixture Author") -> str:
+        self.counter += 1
+        (self.root / "content.txt").write_text(
+            "fixture %d\n" % self.counter, encoding="utf-8"
+        )
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "content.txt"], check=True
+        )
+        return self.commit_staged(message, committer)
+
+    def commit_staged(self, message: str, committer: str) -> str:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GIT_AUTHOR_NAME": committer,
+                "GIT_AUTHOR_EMAIL": "fixture@localhost",
+                "GIT_COMMITTER_NAME": committer,
+                "GIT_COMMITTER_EMAIL": "fixture@localhost",
+            }
+        )
+        subprocess.run(
+            ["git", "-C", str(self.root), "commit", "-q", "-m", message],
+            check=True,
+            env=environment,
+        )
+        return audit.run_git(self.root, "rev-parse", "HEAD")
+
+
+class RepoStateAuditSelfTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="selftest-repo-state-audit.")
+        self.root = pathlib.Path(self.temporary.name) / "repo"
+        self.fixture = RepoFixture(self.root)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_stamp_commit_parsing_and_auto_identity(self) -> None:
+        content = self.fixture.commit("feat: content")
+        first_stamp = self.fixture.commit(
+            "chore(repo-state): %s" % content[:7], audit.BOT_COMMITTER
+        )
+        stamp = self.fixture.commit(
+            "chore(repo-state): retry %s" % content[:7], audit.BOT_COMMITTER
+        )
+        parsed = audit.read_commit(self.root, stamp)
+        self.assertEqual(audit.BOT_COMMITTER, parsed.committer)
+        self.assertTrue(parsed.is_stamp_message)
+        self.assertEqual((first_stamp,), parsed.parents)
+
+        result = audit.classify_identity(
+            self.root,
+            {"stamp_mode": "auto", "describes_commit": content},
+        )
+        self.assertEqual("PASS", result.status)
+
+    def test_auto_identity_rejects_wrong_ancestor_and_wrong_committer(self) -> None:
+        content = self.fixture.commit("feat: content")
+        self.fixture.commit("chore(repo-state): wrong", audit.BOT_COMMITTER)
+        wrong_ancestor = audit.classify_identity(
+            self.root,
+            {"stamp_mode": "auto", "describes_commit": "0" * 40},
+        )
+        self.assertEqual("FAIL", wrong_ancestor.status)
+
+        self.fixture.commit("chore(repo-state): impostor")
+        wrong_committer = audit.classify_identity(
+            self.root,
+            {"stamp_mode": "auto", "describes_commit": content},
+        )
+        self.assertEqual("FAIL", wrong_committer.status)
+
+    def test_auto_content_head_is_transient_drift(self) -> None:
+        content = self.fixture.commit("feat: content")
+        result = audit.classify_identity(
+            self.root,
+            {"stamp_mode": "auto", "describes_commit": content},
+        )
+        self.assertEqual("TRANSIENT", result.status)
+
+        committed_at = audit.read_commit(self.root, "HEAD").committed_at
+        overdue = audit.classify_identity(
+            self.root,
+            {"stamp_mode": "auto", "describes_commit": content},
+            now=committed_at + datetime.timedelta(days=8),
+        )
+        self.assertEqual("FAIL", overdue.status)
+
+    def test_verify_only_uses_base_head_parent_lineage(self) -> None:
+        base = self.fixture.commit("feat: base")
+        self.fixture.commit("feat: merged content")
+        healthy = audit.classify_identity(
+            self.root,
+            {"stamp_mode": "verify-only", "describes_commit": base},
+        )
+        self.assertEqual("PASS", healthy.status)
+
+        stale = audit.classify_identity(
+            self.root,
+            {"stamp_mode": "verify-only", "describes_commit": "0" * 40},
+        )
+        self.assertEqual("FAIL", stale.status)
+
+    def test_missing_status_is_pending(self) -> None:
+        self.fixture.commit("feat: content")
+        result = audit.audit_checkout(
+            "fixture/repo",
+            self.root,
+            {},
+            pathlib.Path("unused-generator"),
+            None,
+            1.0,
+        )
+        self.assertEqual("PENDING", result.status)
+
+    def test_nullable_agents_entry_is_forward_compatible(self) -> None:
+        schema = json.loads(audit.DEFAULT_SCHEMA.read_text(encoding="utf-8"))
+        described = self.fixture.commit("feat: content")
+        status = {
+            "$schema": "https://raw.githubusercontent.com/caty-ai/family-os/main/docs/repo-state/status.schema.json",
+            "schema_version": 1,
+            "generator_version": "repo-state-gen v1",
+            "repo": "fixture/repo",
+            "stamp_mode": "auto",
+            "generated_at": "2026-08-25T01:02:03Z",
+            "describes_commit": described,
+            "describes_commit_date": "2026-08-25T01:02:03Z",
+            "branch": "main",
+            "latest_tag": None,
+            "latest_release_url": None,
+            "agents_entry": None,
+            "canonical_api": "https://api.github.com/repos/fixture/repo/commits/main",
+            "canonical_raw": "https://raw.githubusercontent.com/fixture/repo/%s/status.json"
+            % described,
+            "freshness_contract": "SHA comparison only; dates may only ever trigger distrust. Protocol: docs/repo-state/spec.md, section 'Reader protocol'.",
+        }
+        self.assertEqual([], audit.validate_status(status, schema, "fixture/repo"))
+        expected_block = "\n".join(audit._expected_block(status))
+        (self.root / "README.md").write_text(
+            "# Fixture\n\n%s\n" % expected_block,
+            encoding="utf-8",
+        )
+        (self.root / "status.json").write_text(
+            json.dumps(status, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        result = audit.audit_checkout(
+            "fixture/repo",
+            self.root,
+            schema,
+            audit.DEFAULT_GENERATOR,
+            None,
+            1.0,
+        )
+        self.assertEqual("TRANSIENT", result.status)
+        self.assertFalse((self.root / "AGENTS.md").exists())
+        self.assertFalse((self.root / "FOR-AGENTS.md").exists())
+
+    def test_regeneration_allows_transient_managed_diff_only(self) -> None:
+        (self.root / "README.md").write_text("# Fixture\n", encoding="utf-8")
+        (self.root / "AGENTS.md").write_text("# Agents\n", encoding="utf-8")
+        content = self.fixture.commit("feat: initial content")
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "REPO_STATE_NO_GH": "1",
+                "REPO_STATE_REPO": "fixture/repo",
+                "REPO_STATE_BRANCH": "main",
+            }
+        )
+        subprocess.run(
+            ["sh", str(audit.DEFAULT_GENERATOR), "--stamp-mode", "auto"],
+            cwd=str(self.root),
+            check=True,
+            env=environment,
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "README.md", "AGENTS.md", "status.json"],
+            check=True,
+        )
+        self.fixture.commit_staged(
+            "chore(repo-state): %s" % content[:7], audit.BOT_COMMITTER
+        )
+        self.fixture.commit("feat: next content")
+
+        status = json.loads((self.root / "status.json").read_text(encoding="utf-8"))
+        identity = audit.classify_identity(self.root, status)
+        self.assertEqual("TRANSIENT", identity.status)
+        regeneration = audit.check_regeneration(
+            self.root,
+            "fixture/repo",
+            status,
+            audit.DEFAULT_GENERATOR,
+            identity,
+        )
+        self.assertEqual("PASS", regeneration.status)
+        self.assertIn("stamp-managed regions", regeneration.detail)
+
+        bad_generator = pathlib.Path(self.temporary.name) / "bad-generator.sh"
+        bad_generator.write_text(
+            "#!/bin/sh\nprintf 'unexpected\\n' >> content.txt\n",
+            encoding="utf-8",
+        )
+        outside = audit.check_regeneration(
+            self.root,
+            "fixture/repo",
+            status,
+            bad_generator,
+            identity,
+        )
+        self.assertEqual("FAIL", outside.status)
+        self.assertIn("outside managed regions", outside.detail)
+
+    def test_report_line_format(self) -> None:
+        result = audit.RepoResult(
+            "caty-ai/example",
+            "PASS",
+            ("auto identity invariant holds", "caller success"),
+        )
+        self.assertEqual(
+            "- 2026-08-25 | caty-ai/example | PASS | auto identity invariant holds; caller success",
+            audit.format_report_line(result, "2026-08-25"),
+        )
+
+    def test_universe_enumeration_is_fail_closed_when_required(self) -> None:
+        args = SimpleNamespace(repo=None, timeout=1.0, require_reality=True)
+        with mock.patch.object(audit, "fetch_org_repos", return_value=None):
+            with self.assertRaises(audit.AuditError):
+                audit._repositories(args, {"map_repo": "caty-ai/family-os"})
+
+        args.require_reality = False
+        with mock.patch.object(audit, "fetch_org_repos", return_value=None):
+            repos, degraded_org = audit._repositories(
+                args, {"map_repo": "caty-ai/family-os"}
+            )
+        self.assertIsNone(repos)
+        self.assertEqual("caty-ai", degraded_org)
+
+    def test_actions_known_drift_fails_but_no_token_is_unknown(self) -> None:
+        self.assertEqual("UNKNOWN", audit.check_actions("fixture/repo", None, 1).status)
+
+        unparseable = {"total_count": 1, "workflows": {}}
+        with mock.patch.object(audit, "_http_json", return_value=unparseable):
+            self.assertEqual(
+                "FAIL", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+        truncated = {
+            "total_count": 2,
+            "workflows": [
+                {
+                    "id": 1,
+                    "name": "repository state",
+                    "path": ".github/workflows/repo-state.yml",
+                    "state": "active",
+                }
+            ],
+        }
+        with mock.patch.object(audit, "_http_json", return_value=truncated):
+            self.assertEqual(
+                "FAIL", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+        missing = {"total_count": 0, "workflows": []}
+        with mock.patch.object(audit, "_http_json", return_value=missing):
+            self.assertEqual(
+                "FAIL", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+        disabled = {
+            "total_count": 1,
+            "workflows": [
+                {
+                    "id": 1,
+                    "name": "repository state",
+                    "path": ".github/workflows/repo-state.yml",
+                    "state": "disabled_manually",
+                }
+            ],
+        }
+        with mock.patch.object(audit, "_http_json", return_value=disabled):
+            self.assertEqual(
+                "FAIL", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+        active = {
+            "total_count": 1,
+            "workflows": [
+                {
+                    "id": 1,
+                    "name": "repository state",
+                    "path": ".github/workflows/repo-state.yml",
+                    "state": "active",
+                }
+            ],
+        }
+        bad_id = {
+            "total_count": 1,
+            "workflows": [dict(active["workflows"][0], id="not-an-integer")],
+        }
+        with mock.patch.object(audit, "_http_json", return_value=bad_id):
+            self.assertEqual(
+                "FAIL", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+        bad_runs = {"workflow_runs": {}}
+        with mock.patch.object(audit, "_http_json", side_effect=[active, bad_runs]):
+            self.assertEqual(
+                "FAIL", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+        failed_run = {
+            "workflow_runs": [{"status": "completed", "conclusion": "failure"}]
+        }
+        with mock.patch.object(audit, "_http_json", side_effect=[active, failed_run]):
+            self.assertEqual(
+                "FAIL", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+        with mock.patch.object(audit, "_http_json", side_effect=OSError):
+            self.assertEqual(
+                "UNKNOWN", audit.check_actions("fixture/repo", "fixture-token", 1).status
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/selftest_repo_state_audit.py
+++ b/tools/selftest_repo_state_audit.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import datetime
+import io
 import json
 import os
 import pathlib
@@ -183,16 +184,30 @@ class RepoStateAuditSelfTest(unittest.TestCase):
             json.dumps(status, indent=2) + "\n",
             encoding="utf-8",
         )
-
-        result = audit.audit_checkout(
-            "fixture/repo",
-            self.root,
-            schema,
-            audit.DEFAULT_GENERATOR,
-            None,
-            1.0,
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "README.md", "status.json"],
+            check=True,
         )
-        self.assertEqual("TRANSIENT", result.status)
+        self.fixture.commit_staged(
+            "chore(repo-state): %s" % described[:7], audit.BOT_COMMITTER
+        )
+
+        with mock.patch.object(
+            audit, "check_actions", return_value=audit.Check("PASS", "caller success")
+        ):
+            result = audit.audit_checkout(
+                "fixture/repo",
+                self.root,
+                schema,
+                audit.DEFAULT_GENERATOR,
+                "fixture-token",
+                1.0,
+            )
+        self.assertEqual("UNKNOWN", result.status)
+        self.assertIn(
+            "regeneration skipped: v0.11.0 generator cannot run without an agents entry",
+            result.details,
+        )
         self.assertFalse((self.root / "AGENTS.md").exists())
         self.assertFalse((self.root / "FOR-AGENTS.md").exists())
 
@@ -276,6 +291,106 @@ class RepoStateAuditSelfTest(unittest.TestCase):
             )
         self.assertIsNone(repos)
         self.assertEqual("caty-ai", degraded_org)
+
+    def test_actions_api_retries_anonymously_after_token_http_error(self) -> None:
+        url = "https://api.github.com/repos/fixture/repo/actions/workflows"
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b'{"workflows": []}'
+        forbidden = audit.urllib.error.HTTPError(url, 403, "Forbidden", {}, None)
+        opener = mock.MagicMock()
+        opener.open.side_effect = [forbidden, response]
+
+        with mock.patch.object(
+            audit.urllib.request, "build_opener", return_value=opener
+        ):
+            payload = audit._http_json(url, "fixture-token", 1.0)
+        forbidden.close()
+
+        self.assertEqual({"workflows": []}, payload)
+        self.assertEqual(2, opener.open.call_count)
+        first_request = opener.open.call_args_list[0].args[0]
+        second_request = opener.open.call_args_list[1].args[0]
+        self.assertEqual(
+            "Bearer fixture-token", first_request.get_header("Authorization")
+        )
+        self.assertIsNone(second_request.get_header("Authorization"))
+
+    def test_actions_api_is_unknown_when_token_and_anonymous_calls_fail(self) -> None:
+        url = "https://api.github.com/repos/fixture/repo/actions/workflows"
+        forbidden = audit.urllib.error.HTTPError(url, 403, "Forbidden", {}, None)
+        opener = mock.MagicMock()
+        opener.open.side_effect = [forbidden, forbidden]
+
+        with mock.patch.object(
+            audit.urllib.request, "build_opener", return_value=opener
+        ):
+            result = audit.check_actions("fixture/repo", "fixture-token", 1.0)
+        forbidden.close()
+
+        self.assertEqual("UNKNOWN", result.status)
+        self.assertEqual("caller UNKNOWN(api-error)", result.detail)
+        self.assertEqual(2, opener.open.call_count)
+
+    def test_clone_without_origin_main_is_pending(self) -> None:
+        source = pathlib.Path(self.temporary.name) / "trunk-source"
+        source_fixture = RepoFixture(source)
+        source_fixture.commit("feat: trunk content")
+        subprocess.run(
+            ["git", "-C", str(source), "branch", "-m", "trunk"], check=True
+        )
+        destination = pathlib.Path(self.temporary.name) / "trunk-clone"
+        real_run = subprocess.run
+
+        def clone_fixture(command, **kwargs):
+            command = list(command)
+            if command[:2] == ["git", "clone"]:
+                command[-2] = str(source)
+            return real_run(command, **kwargs)
+
+        with mock.patch.object(audit.subprocess, "run", side_effect=clone_fixture):
+            result = audit._clone_main("fixture/repo", destination, 5.0)
+
+        self.assertEqual(
+            audit.Check("PENDING", "no main branch (empty or non-main default)"),
+            result,
+        )
+
+    def test_required_all_clone_unknown_is_fail_closed_but_mixed_is_not(self) -> None:
+        clone_unknown = audit.Check("UNKNOWN", "clone unavailable")
+        argv = [
+            "--repo",
+            "fixture/one",
+            "--repo",
+            "fixture/two",
+            "--require-reality",
+        ]
+        stderr = io.StringIO()
+        with mock.patch.object(audit, "_clone_main", return_value=clone_unknown):
+            with mock.patch.object(audit.sys, "stdout", io.StringIO()):
+                with mock.patch.object(audit.sys, "stderr", stderr):
+                    exit_code = audit.main(argv)
+        self.assertEqual(2, exit_code)
+        self.assertIn("all repositories are clone-unavailable", stderr.getvalue())
+
+        pending = audit.RepoResult(
+            "fixture/two", "PENDING", ("status.json absent (rollout not landed)",)
+        )
+        with mock.patch.object(
+            audit, "_clone_main", side_effect=[clone_unknown, None]
+        ):
+            with mock.patch.object(audit, "audit_checkout", return_value=pending):
+                with mock.patch.object(audit.sys, "stdout", io.StringIO()):
+                    mixed_exit_code = audit.main(argv)
+        self.assertEqual(0, mixed_exit_code)
+
+        drift = audit.RepoResult("fixture/two", "FAIL", ("drift",))
+        with mock.patch.object(
+            audit, "_clone_main", side_effect=[clone_unknown, None]
+        ):
+            with mock.patch.object(audit, "audit_checkout", return_value=drift):
+                with mock.patch.object(audit.sys, "stdout", io.StringIO()):
+                    drift_exit_code = audit.main(argv)
+        self.assertEqual(1, drift_exit_code)
 
     def test_actions_known_drift_fails_but_no_token_is_unknown(self) -> None:
         self.assertEqual("UNKNOWN", audit.check_actions("fixture/repo", None, 1).status)

--- a/tools/selftest_repo_state_audit.py
+++ b/tools/selftest_repo_state_audit.py
@@ -153,7 +153,7 @@ class RepoStateAuditSelfTest(unittest.TestCase):
         )
         self.assertEqual("PENDING", result.status)
 
-    def test_nullable_agents_entry_is_forward_compatible(self) -> None:
+    def test_nullable_agents_entry_generator_failure_is_unknown(self) -> None:
         schema = json.loads(audit.DEFAULT_SCHEMA.read_text(encoding="utf-8"))
         described = self.fixture.commit("feat: content")
         status = {
@@ -191,6 +191,62 @@ class RepoStateAuditSelfTest(unittest.TestCase):
         self.fixture.commit_staged(
             "chore(repo-state): %s" % described[:7], audit.BOT_COMMITTER
         )
+        stub_generator = pathlib.Path(self.temporary.name) / "stub-generator.sh"
+        stub_generator.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' 'neither FOR-AGENTS.md nor AGENTS.md exists' >&2\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(
+            audit, "check_actions", return_value=audit.Check("PASS", "caller success")
+        ):
+            result = audit.audit_checkout(
+                "fixture/repo",
+                self.root,
+                schema,
+                stub_generator,
+                "fixture-token",
+                1.0,
+            )
+        self.assertEqual("UNKNOWN", result.status)
+        self.assertIn(
+            "regeneration skipped: v0.11.0 generator cannot run without an agents entry",
+            result.details,
+        )
+        self.assertFalse((self.root / "AGENTS.md").exists())
+        self.assertFalse((self.root / "FOR-AGENTS.md").exists())
+
+    def test_nullable_agents_entry_real_generator_is_byte_clean(self) -> None:
+        schema = json.loads(audit.DEFAULT_SCHEMA.read_text(encoding="utf-8"))
+        (self.root / "README.md").write_text("# Fixture\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "README.md"], check=True
+        )
+        described = self.fixture.commit("feat: content")
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "REPO_STATE_NO_GH": "1",
+                "REPO_STATE_REPO": "fixture/repo",
+                "REPO_STATE_BRANCH": "main",
+            }
+        )
+        subprocess.run(
+            ["sh", str(audit.DEFAULT_GENERATOR), "--stamp-mode", "auto"],
+            cwd=str(self.root),
+            check=True,
+            env=environment,
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "README.md", "status.json"],
+            check=True,
+        )
+        self.fixture.commit_staged(
+            "chore(repo-state): %s" % described[:7], audit.BOT_COMMITTER
+        )
 
         with mock.patch.object(
             audit, "check_actions", return_value=audit.Check("PASS", "caller success")
@@ -203,13 +259,12 @@ class RepoStateAuditSelfTest(unittest.TestCase):
                 "fixture-token",
                 1.0,
             )
-        self.assertEqual("UNKNOWN", result.status)
-        self.assertIn(
-            "regeneration skipped: v0.11.0 generator cannot run without an agents entry",
-            result.details,
-        )
+        status = json.loads((self.root / "status.json").read_text(encoding="utf-8"))
+        self.assertEqual("PASS", result.status)
+        self.assertIn("canonical regeneration is byte-clean", result.details)
         self.assertFalse((self.root / "AGENTS.md").exists())
         self.assertFalse((self.root / "FOR-AGENTS.md").exists())
+        self.assertIsNone(status["agents_entry"])
 
     def test_regeneration_allows_transient_managed_diff_only(self) -> None:
         (self.root / "README.md").write_text("# Fixture\n", encoding="utf-8")


### PR DESCRIPTION
## Why

Closes #134. Parent #127 Done-when: the weekly audit catches drift the PR check cannot (dead stampers, disabled callers, out-of-band edits). Design frozen in #127 DESIGN v0.2 §3.3 (3-seat design review integrated).

## What (1267 added / 2 deleted — matches WIP declaration on #134)

- `tools/repo_state_audit.py` (new, 819 lines): per-repo checks a–e — status.json presence+schema, **identity invariant** (auto: HEAD is a bot stamp commit ∧ describes_commit == nearest non-stamp ancestor; content-commit HEAD = TRANSIENT drift; verify-only per spec §5), regenerate-and-diff limited to stamp-managed regions, latest caller-run conclusion via Actions API (UNKNOWN(no-token) degradation), dated report lines. **PENDING** for repos without status.json (rollout sequencing never reads as red). Universe = registry org enumeration, `--require-reality` fail-closed on scheduled runs; per-repo clone failures are recorded UNKNOWN, never silently dropped.
- `tools/selftest_repo_state_audit.py` (new, 302 lines, 10 tests): identity true/false, transient, PENDING, null and string `agents_entry` (v0.11.1 compat), report formatting, Actions-check classifications.
- `.github/workflows/family-links.yml`: new `repo-state-audit` job (schedule+dispatch only); `report` job now `always()`-gated with the failure step preserved via `contains(needs.*.result,'failure')` + success-side heartbeat appended as dated comments to a standing "Weekly repo-state audit heartbeat" issue (find-or-create by stable title; no double-filing). `permissions: actions: read` added.
- `Makefile`: selftest wired into `test`.

## Verification (writer=Codex GPT-5.6 Sol self-verify + Alpha independent re-run, 2026-08-25/26)

- `python3 -B tools/selftest_repo_state_audit.py` → 10 tests OK (both runs)
- `make test` → all green incl. existing suites
- `actionlint` on family-links.yml → OK
- Live single-repo dry-run: PENDING classification on a pre-rollout mirror; UNKNOWN degradation on clone-unavailable — both exit 0
- TODO/placeholder/test.skip grep → 0 hits

## Gates

- Touches `.github/workflows/**` → owner risk-gate label (second click, as pre-announced in the #127 batch).
- **pr-size 250 exceeded → needs owner `size-exempt` (after final push)**.
- 3-seat merge review starts now (writer=Codex → Kimi/Opus/GLM panel); merge only after cumulative GO + labels.

## Out of scope (follow-up lane)

FMA schedule-liveness probe watching this report's absence (>8 days ⇒ alert) — filed on family-memory-architecture after the report format ships here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## L1-7 completion record (merge-time, 2026-08-26)

- **Candidate SHA**: `33325ff6d9e4427f7c3d2de929c665e24990852c` (= PR head at merge). L1-8 supersession note: the record was first written at `3398fa4` (cumulative 3/3 GO); merge re-verification then caught a #135-interaction (the nullable-agents selftest assumed the repo generator was v0.11.0; on merged main the v0.11.1 generator runs and the UNKNOWN expectation failed) — main was reset before any push, the branch was rebased onto main and one test-only commit (+57/−2, selftest file only) split the test into a hermetic UNKNOWN-path (stub generator; mutation-verified) + a live v0.11.1 forward-path (overall PASS, byte-clean regeneration). Selftests 15/15, make test green. Delta-2 confirmation: Opus 5 verified the commit is test-only (audit tool and workflow byte-identical to its reviewed snapshot), re-ran its own fixtures, and carried the cumulative GO to `33325ff`.
- **Done when** (issue #134):
  1. Weekly/dispatch dated per-repo lines a–d in the report flow; fail-closed enumeration — **PASS** (round-1 FAIL on the dispatch/drift branches → delta: heartbeat on any non-skipped result + dispatch parity + `--require-reality` on dispatch; verified by all 3 delta seats via diff + workflow-logic audit; live end-to-end exercised post-merge per the agreed dispatch verification).
  2. Identity invariant proven on healthy auto / PENDING / dead-stamper — **PASS** (all 3 seats built independent git fixtures: healthy single/double-stamp PASS, stranded and re-emitted dead stampers FAIL, PENDING on missing status.json; position-shortcut mutation turns `test_stamp_commit_parsing_and_auto_identity` red — mutation-verified by Kimi and Opus).
  3. Selftests green; `make test` green; no PR-check semantics change — **PASS** (14/14 selftests + make test green: writer, integrator, and all 3 seats independently; PR/push check jobs untouched by the diff).
- **File set vs diff**: `tools/repo_state_audit.py` (new), `tools/selftest_repo_state_audit.py` (new), `.github/workflows/family-links.yml`, `Makefile`, `docs/repo-state/spec.md` (§4, one sentence) — matches the WIP declaration on #134 incl. the delta-round update (spec.md/Makefile addition declared with reasons; #135-first serialization honored: #135 merged before this PR).
- **Identities**: writer = Codex GPT-5.6 Sol (impl + review delta, via sitter-run); reviewers = Kimi K3 / GLM 5.3 / Opus 5 (fresh-context, read-only, blind round 1 with per-seat verdicts; delta pass on per-seat independent snapshot copies; requested=actual both rounds); integrator = Alpha (Claude Fable 5), commits as shojikumaru noreply.
- **Review records**: round 1 = PR comment-5414070936 (incl. material-integrity incident disclosure and GLM flip evidence); delta cumulative 3/3 GO = comment-5414208862.
- **CI**: all checks green; owner labels `risk-reviewed` + `size-exempt` applied 2026-08-26.
- **Post-merge verification (agreed condition)**: one `workflow_dispatch` run — (a) sub-check (d) resolving non-UNKNOWN for a repo other than family-os, (b) heartbeat comment landing on a non-success audit result. Executed immediately after merge; result recorded in a follow-up comment.
- **release**: v0.12.0 (this merge; annotated tag + release-sync auto Release). **previous release**: v0.11.1 (re-measured before tagging).

