### PR TITLE
repo-state: authenticate stamp pushes as the org GitHub App (v0.11.2)

### DIFF
--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -18,9 +18,10 @@ name: repository state
 #   cancel-in-progress: false
 # jobs:
 #   repo-state:
-#     uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.1
+#     uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.2
+#     secrets: inherit
 #     with:
-#       generator_ref: v0.11.1
+#       generator_ref: v0.11.2
 #
 # The `uses:` ref and `generator_ref` must always move together: a v0.11.0
 # workflow with a v0.11.1 generator fails at `git add` on a repository whose
@@ -42,11 +43,22 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' &&
        github.actor != 'github-actions[bot]' &&
+       github.actor != 'caty-repo-state-bot[bot]' &&
        !startsWith(github.event.head_commit.message, 'chore(repo-state):'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      APP_ID: ${{ secrets.REPO_STATE_APP_ID }}
     steps:
+      - name: mint stamp push token
+        id: app-token
+        if: env.APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.REPO_STATE_APP_ID }}
+          private-key: ${{ secrets.REPO_STATE_APP_PRIVATE_KEY }}
+
       - name: check out default branch for release or dispatch
         if: github.event_name != 'push'
         uses: actions/checkout@v4
@@ -54,6 +66,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: check out pushed commit
         if: github.event_name == 'push'
@@ -62,6 +75,7 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: fetch pinned generator
         env:

--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -50,14 +50,25 @@ jobs:
       contents: write
     env:
       APP_ID: ${{ secrets.REPO_STATE_APP_ID }}
+      APP_KEY: ${{ secrets.REPO_STATE_APP_PRIVATE_KEY }}
     steps:
       - name: mint stamp push token
         id: app-token
-        if: env.APP_ID != ''
+        if: env.APP_ID != '' && env.APP_KEY != ''
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.REPO_STATE_APP_ID }}
           private-key: ${{ secrets.REPO_STATE_APP_PRIVATE_KEY }}
+
+      - name: report push credential mode
+        env:
+          TOKEN_PRESENT: ${{ steps.app-token.outputs.token != '' }}
+        run: |
+          if [ "$TOKEN_PRESENT" = "true" ]; then
+            echo "stamp pushes authenticate as the org app"
+          else
+            echo "no complete app credentials; falling back to GITHUB_TOKEN (v0.11.1 behavior)"
+          fi
 
       - name: check out default branch for release or dispatch
         if: github.event_name != 'push'

--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -18,10 +18,10 @@ name: repository state
 #   cancel-in-progress: false
 # jobs:
 #   repo-state:
-#     uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.11.2
+#     uses: caty-ai/family-os/.github/workflows/repo-state.yml@v0.12.1
 #     secrets: inherit
 #     with:
-#       generator_ref: v0.11.2
+#       generator_ref: v0.12.1
 #
 # The `uses:` ref and `generator_ref` must always move together: a v0.11.0
 # workflow with a v0.11.1 generator fails at `git add` on a repository whose

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -84,8 +84,9 @@ not hand reviewers branch-pinned raw URLs and do not use dates as evidence of fr
 
 The reusable workflow has two jobs. `update` runs for default-branch pushes, published
 releases, and manual dispatches. Push events alone are skipped when the actor is
-`github-actions[bot]` or the head commit message begins `chore(repo-state):`. Release and
-manual events are never skipped. Push runs preserve the existing release fields and do
+`github-actions[bot]` or the organization's stamp app, or the head commit message begins
+`chore(repo-state):`. Release and manual events are never skipped. Push runs preserve the
+existing release fields and do
 not query GitHub releases. Release and manual-dispatch runs check out the default branch
 HEAD, not the release tag, and they refresh release metadata by running
 `repo-state-gen.sh --stamp-mode auto --refresh-release`. An explicit GitHub 404 maps the

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -103,6 +103,7 @@ Automatic mode requires the recorded, scoped canon exception that allows
 `github-actions[bot]` to push only `chore(repo-state):` commits to the default branch;
 all other direct pushes remain forbidden. Branch protection must grant that bot the
 corresponding allowance where protection exists.
+Where a repository provides dedicated credentials, automatic-mode pushes authenticate as an organization-dedicated GitHub App and any ruleset bypass is scoped to that app.
 
 The `check` job runs for pull requests and invokes only `repo-state-gen.sh --check`. It
 requires a schema-valid `status.json`, a valid marker block in the entire stamped-file


### PR DESCRIPTION
## Why

Closes #140. Parent #127. Org-wide required checks block `GITHUB_TOKEN` stamp pushes and no bypass admits the Actions identity (all alternatives empirically exhausted — see #140). Owner decision: dedicated org App `caty-repo-state-bot` (4728478, contents RW, org-installed; per-repo secrets distributed; ruleset Integration bypass validated).

## What (17 added / 2 deleted; matches WIP on #140)

- `.github/workflows/repo-state.yml` update job: job env `APP_ID`; `actions/create-github-app-token@v2` step gated on `env.APP_ID != ''`; both checkouts get `token: ${{ steps.app-token.outputs.token || github.token }}` (app token when configured, byte-equivalent `GITHUB_TOKEN` fallback when not); loop guard extended with `caty-repo-state-bot[bot]` actor skip; header example bumps both refs to v0.11.2 + `secrets: inherit`.
- `docs/repo-state/spec.md` §4: one sentence documenting app-authenticated pushes with app-scoped ruleset bypass.
- Git identities unchanged (commits stay `github-actions[bot]` → weekly-audit identity invariant untouched); check job untouched; `GH_TOKEN` for the read-only release refresh stays `GITHUB_TOKEN`.

## Verification (writer=Codex Sol + Alpha re-run, 2026-08-26)

- actionlint clean; `make test` green (both).
- Static 4-path trace in the writer's report: with-secrets push / without-secrets fallback / app-actor loop skip / pull_request untouched.
- Live end-to-end (Done-when item 1) executes on the sitter dispatch after tag v0.11.2 + caller bump — **deferred until the current GitHub Actions major outage clears** (statuspage measured 2026-08-26; local verification unaffected).

## Gate

Touches `.github/workflows/**` → owner risk-gate label (next label batch). 3-seat review (Kimi/GLM/Opus) starting now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## L1-7 completion record (merge-time, 2026-08-27 JST)

- **Candidate SHA**: `8e6be5b` (= PR head at merge; cumulative panel GO bound here)
- **Done when** (issue #140):
  1. Secret-bearing caller pushes the stamp through the app-bypass ruleset — **PASS, live**: pre-merge throwaway branch-pinned caller on sitter (run 32997957210) minted the token, printed the app-path credential line, and landed `chore(repo-state): 85feb6f` on sitter main through the ruleset; status.json self-healed (`branch: main`, release fields refreshed).
  2. Caller without secrets identical to v0.11.1 — **PASS**: 3 seats traced the expression semantics independently (empty secret → skipped mint → `|| github.token`); credential-mode log makes the fallback observable.
  3. Loop closed — **PASS, live**: follow-on push run 32998005341 actor = exactly `caty-repo-state-bot[bot]`, update job skipped; message-prefix guard as independent backstop.
  4. `make test` green; check job + git identities untouched — **PASS** (writer, integrator, and all 3 seats re-ran from copies).
- **Review**: round 1 blind 3 seats (per-seat snapshot copies) Kimi GO-w/c / GLM GO / Opus GO-w/c at `ac2c57d`; adopted delta `8e6be5b` (3-seat convergent dual-secret gate + credential log; spec §4 guard wording); Opus independently re-verified the delta and carried **cumulative GO**; the single shared condition (live check) discharged above. Records: #140 comment-5428189211 / -5428239045 / -5429234031.
- **Findings dispositions**: F1 discharged by 7-repo survey (no push-triggered release path; residual = DESIGN §3.4 priced CI increase); F5 accepted risk (secrets: inherit, first-party workflow); F6 handbook wording rides lane (a) (handbook PR #19 thread).
- **File set vs diff**: `.github/workflows/repo-state.yml` + `docs/repo-state/spec.md` — matches WIP on #140.
- **Identities**: writer = Codex GPT-5.6 Sol (impl + both deltas); reviewers = Kimi K3 / GLM 5.3 / Opus 5 (requested=actual); integrator = Alpha, commits as shojikumaru noreply.
- **CI**: green; owner `risk-reviewed` label 2026-08-27 JST.
- **release**: v0.11.2 (this merge; annotated tag + release-sync auto Release). **previous release**: re-measured immediately before tagging.
