### PR TITLE
repo-state audit: judge the latest non-skipped caller run (#143)

### DIFF
--- a/tools/repo_state_audit.py
+++ b/tools/repo_state_audit.py
@@ -559,7 +559,7 @@ def check_actions(repo: str, token: Optional[str], timeout: float) -> Check:
             return Check("FAIL", "repo-state caller workflow id is unparseable")
 
         runs = _http_json(
-            "https://api.github.com/repos/%s/actions/workflows/%d/runs?branch=main&per_page=1"
+            "https://api.github.com/repos/%s/actions/workflows/%d/runs?branch=main&per_page=100"
             % (encoded_repo, workflow_id),
             token,
             timeout,
@@ -568,19 +568,27 @@ def check_actions(repo: str, token: Optional[str], timeout: float) -> Check:
         if not isinstance(workflow_runs, list):
             return Check("FAIL", "repo-state caller run list is unparseable")
         if not workflow_runs:
-            return Check("FAIL", "repo-state caller has no main-branch runs")
-        latest = workflow_runs[0]
-        if not isinstance(latest, dict):
-            return Check("FAIL", "latest repo-state caller run is unparseable")
-        run_status = latest.get("status")
-        conclusion = latest.get("conclusion")
-        if run_status != "completed":
-            if not isinstance(run_status, str):
-                return Check("FAIL", "latest repo-state caller status is unparseable")
-            return Check("UNKNOWN", "caller UNKNOWN(%s)" % (run_status or "unparseable"))
-        if conclusion != "success":
-            return Check("FAIL", "latest repo-state caller conclusion is %s" % conclusion)
-        return Check("PASS", "latest repo-state caller conclusion is success")
+            return Check("UNKNOWN", "no main-branch caller runs yet")
+        saw_in_progress = False
+        for run in workflow_runs:
+            if not isinstance(run, dict):
+                return Check("FAIL", "latest repo-state caller run is unparseable")
+            conclusion = run.get("conclusion")
+            if conclusion in {"skipped", "cancelled"}:
+                continue
+            if conclusion is None:
+                saw_in_progress = True
+                continue
+            if conclusion != "success":
+                return Check(
+                    "FAIL", "latest repo-state caller conclusion is %s" % conclusion
+                )
+            return Check("PASS", "latest repo-state caller conclusion is success")
+        if saw_in_progress:
+            return Check("UNKNOWN", "no terminal caller run yet")
+        return Check(
+            "UNKNOWN", "only skipped/cancelled caller runs in the latest page"
+        )
     except (
         AuditError,
         OSError,

--- a/tools/selftest_repo_state_audit.py
+++ b/tools/selftest_repo_state_audit.py
@@ -75,6 +75,26 @@ class RepoStateAuditSelfTest(unittest.TestCase):
     def tearDown(self) -> None:
         self.temporary.cleanup()
 
+    def _check_actions_with_runs(self, workflow_runs):
+        active = {
+            "total_count": 1,
+            "workflows": [
+                {
+                    "id": 1,
+                    "name": "repository state",
+                    "path": ".github/workflows/repo-state.yml",
+                    "state": "active",
+                }
+            ],
+        }
+        runs = {"workflow_runs": workflow_runs}
+        with mock.patch.object(
+            audit, "_http_json", side_effect=[active, runs]
+        ) as http_json:
+            result = audit.check_actions("fixture/repo", "fixture-token", 1)
+        self.assertIn("per_page=100", http_json.call_args_list[1].args[0])
+        return result
+
     def test_stamp_commit_parsing_and_auto_identity(self) -> None:
         content = self.fixture.commit("feat: content")
         first_stamp = self.fixture.commit(
@@ -532,6 +552,62 @@ class RepoStateAuditSelfTest(unittest.TestCase):
             self.assertEqual(
                 "UNKNOWN", audit.check_actions("fixture/repo", "fixture-token", 1).status
             )
+
+    def test_actions_uses_success_behind_newest_skipped_run(self) -> None:
+        result = self._check_actions_with_runs(
+            [
+                {"status": "completed", "conclusion": "skipped"},
+                {"status": "completed", "conclusion": "success"},
+            ]
+        )
+        self.assertEqual(
+            audit.Check("PASS", "latest repo-state caller conclusion is success"),
+            result,
+        )
+
+    def test_actions_uses_failure_behind_newest_skipped_run(self) -> None:
+        result = self._check_actions_with_runs(
+            [
+                {"status": "completed", "conclusion": "skipped"},
+                {"status": "completed", "conclusion": "failure"},
+            ]
+        )
+        self.assertEqual(
+            audit.Check("FAIL", "latest repo-state caller conclusion is failure"),
+            result,
+        )
+
+    def test_actions_all_skipped_or_cancelled_runs_are_unknown(self) -> None:
+        result = self._check_actions_with_runs(
+            [
+                {"status": "completed", "conclusion": "skipped"},
+                {"status": "completed", "conclusion": "cancelled"},
+            ]
+        )
+        self.assertEqual(
+            audit.Check(
+                "UNKNOWN", "only skipped/cancelled caller runs in the latest page"
+            ),
+            result,
+        )
+
+    def test_actions_empty_run_list_is_unknown(self) -> None:
+        result = self._check_actions_with_runs([])
+        self.assertEqual(
+            audit.Check("UNKNOWN", "no main-branch caller runs yet"), result
+        )
+
+    def test_actions_uses_success_behind_in_progress_run(self) -> None:
+        result = self._check_actions_with_runs(
+            [
+                {"status": "in_progress", "conclusion": None},
+                {"status": "completed", "conclusion": "success"},
+            ]
+        )
+        self.assertEqual(
+            audit.Check("PASS", "latest repo-state caller conclusion is success"),
+            result,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Closes #143. First full live audit false-FAILed all 8 healthy repos: the newest caller run is always the bot's own loop-guard-skipped stamp-push run, and `check_actions` judged only that newest run.

## What (+98/−14, 2 files)

- `check_actions`: fetch up to 100 main-branch runs, iterate newest→oldest past `skipped`/`cancelled`; judge the first terminal conclusion (success=PASS, else FAIL naming it); in-progress runs are skipped while looking (UNKNOWN "no terminal caller run yet" if nothing terminal behind); skipped-only page → UNKNOWN (healthy steady state); no runs → UNKNOWN (brand-new caller must not alarm).
- Selftests 15 → 20: newest-skipped→success PASS / newest-skipped→failure FAIL / all-skipped UNKNOWN / empty UNKNOWN / in-progress→success PASS. Writer mutation-verified (newest-only revert turns the suite red).

## Verification

Selftest 20/20 + make test green (writer + integrator). Post-merge: dispatch expected to turn all 8 rolled-out repos PASS.

## Gate

tools/** → risk-gate label (one more click, sorry). Delta-style review by the #136 panel runs now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## L1-7 completion record (merge-time, 2026-08-27 JST)

- **Candidate SHA**: `b541b00` (= PR head at merge; 3/3 delta panel GO bound here).
- **Done when** (issue #143): 1. selftests green incl. the four new (d)-cases — **PASS** (20/20; writer + integrator + all 3 seats re-ran; writer mutation-verified newest-only revert goes red). 2. live dispatch turns the 8 rolled-out repos PASS — **executed immediately post-merge, result appended below in a follow-up comment**.
- **Review**: delta panel (same seats as PR #136; per-seat copies): Kimi GO / Opus GO / GLM GO — each probed check_actions with own mocks (buried-failure FAIL, skipped-only UNKNOWN, empty UNKNOWN, in-progress handling); non-blocking LOWs recorded as #145.
- **File set vs diff**: tools/repo_state_audit.py + tools/selftest_repo_state_audit.py — matches WIP on #143.
- **Identities**: writer = Codex GPT-5.6 Sol; reviewers = Kimi K3 / GLM 5.3 / Opus 5; integrator = Alpha (shojikumaru noreply).
- **CI**: green; owner risk-reviewed label 2026-08-27 JST (post-final-push head).
- **release**: v0.13.1 (this merge). **previous release**: v0.13.0. Correction record (L1-8): v0.12.3 was tagged first — the pre-tag re-measure DID show v0.13.0 (shipped minutes earlier by the #138/#142 lane) but the tag command was chained and ran before the reading was acted on. v0.12.3 tag + Release deleted within minutes (no consumers), replaced by v0.13.1 on the same merge commit 86b347d. Lesson: the re-measure must gate the tag, not merely precede it.

