### PR TITLE
fix(registry): persona-engine tagline — align with canonical README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -369,7 +369,7 @@ Family OS が広がっても、次の5つは変わりません。
 | 掟 | [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | 開発の交通ルール — Issue・PR・worktree・受け渡し・並行開発 | 公開・MIT |
 | 縦軸・基盤 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | AIエージェントのタスク基盤 — 試行・リトライ・チェックポイント・完了判定 | 公開・MIT |
 | 縦軸 | [context-kit](https://github.com/caty-ai/context-kit) | エージェント1体分の6点コンテキスト衛生キット — 大出力の退避・委譲ブリーフ検査・安全フック・記憶検索・worktree スナップショット | 公開・MIT |
-| 縦軸 | [Persona Engine](https://github.com/caty-ai/persona-engine) | エージェントに人格を与える — 人格レイヤーと感情のグラデーション | 公開・MIT |
+| 縦軸 | [Persona Engine](https://github.com/caty-ai/persona-engine) | エージェントの既存人格に関係と感情のレイヤーを重ねる | 公開・MIT |
 | 縦軸 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | 人格そのものを育てる — 最小・冪等な提案づくり | 公開・MIT |
 | 縦軸 | [X Collector](https://github.com/caty-ai/x-collector) | Xやウェブの素材を1日1回のダイジェストに — 人にもエージェントにも | 公開・MIT |
 | 縦軸 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | エージェントが自分の能力を育てるループ — 提案・ガバナンス・採用記録 | 公開・MIT |

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Every module on this map, with its current state — generated from the same reg
 | Rules | [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | The rules of the road — issues, PRs, worktrees, handoffs, parallel development | published, MIT |
 | Vertical · foundation | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | Task backbone for AI agents — retries, checkpoints, and honest completion | published, MIT |
 | Vertical | [context-kit](https://github.com/caty-ai/context-kit) | Six-piece context hygiene kit for one agent — bounded output, delegation briefs, safety guards, recall, worktree snapshots | published, MIT |
-| Vertical | [Persona Engine](https://github.com/caty-ai/persona-engine) | Gives an agent a persona — layered personality and graded emotion | published, MIT |
+| Vertical | [Persona Engine](https://github.com/caty-ai/persona-engine) | Layers relationship and emotion onto an agent's existing persona | published, MIT |
 | Vertical | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | Grows the persona itself — minimal, idempotent proposals | published, MIT |
 | Vertical | [X Collector](https://github.com/caty-ai/x-collector) | Turns X and the web into one daily digest — for people and agents | published, MIT |
 | Vertical | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | Lets an agent grow its own abilities — proposals, governance, adoption records | published, MIT |

--- a/README.th.md
+++ b/README.th.md
@@ -369,7 +369,7 @@ flowchart TB
 | กติกา | [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | กติกากลางของการพัฒนา — Issue, PR, worktree, การส่งงานต่อ และการทำงานคู่ขนาน | เปิดแล้ว・MIT |
 | แกนตั้ง · รากฐาน | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | แกนงานของเอเจนต์ AI — การลองใหม่ เช็คพอยต์ และการตัดสินว่าเสร็จจริง | เปิดแล้ว・MIT |
 | แกนตั้ง | [context-kit](https://github.com/caty-ai/context-kit) | ชุดดูแลคอนเท็กซ์ 6 ชิ้นสำหรับเอเจนต์หนึ่งตัว — จำกัดเอาต์พุตขนาดใหญ่, ตรวจ brief การมอบงาน, การ์ดความปลอดภัย, ค้นความทรงจำ, snapshot ของ worktree | เปิดแล้ว・MIT |
-| แกนตั้ง | [Persona Engine](https://github.com/caty-ai/persona-engine) | มอบบุคลิกให้เอเจนต์ — เลเยอร์บุคลิกและอารมณ์แบบไล่ระดับ | เปิดแล้ว・MIT |
+| แกนตั้ง | [Persona Engine](https://github.com/caty-ai/persona-engine) | ซ้อนเลเยอร์ความสัมพันธ์และอารมณ์บนบุคลิกเดิมของเอเจนต์ | เปิดแล้ว・MIT |
 | แกนตั้ง | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | พัฒนาบุคลิกของเอเจนต์ — สร้างข้อเสนอแบบน้อยที่สุดและทำซ้ำได้ | เปิดแล้ว・MIT |
 | แกนตั้ง | [X Collector](https://github.com/caty-ai/x-collector) | รวบรวมข้อมูลจาก X และเว็บเป็นสรุปวันละฉบับ — สำหรับคนและเอเจนต์ | เปิดแล้ว・MIT |
 | แกนตั้ง | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | วงจรให้เอเจนต์พัฒนาความสามารถของตัวเอง — ข้อเสนอ ธรรมาภิบาล และบันทึกการนำไปใช้ | เปิดแล้ว・MIT |

--- a/README.zh.md
+++ b/README.zh.md
@@ -369,7 +369,7 @@ Family OS 这边没有要做的事。不用安装，不用注册账号，也没�
 | 规则 | [Family Dev Handbook](https://github.com/caty-ai/family-dev-handbook) | 开发的交通规则 — Issue、PR、worktree、交接与并行开发 | 已公开・MIT |
 | 纵轴・基座 | [Caty Agent Harness](https://github.com/caty-ai/caty-agent-harness) | AI 智能体的任务基座 — 重试、检查点与完成判定 | 已公开・MIT |
 | 纵轴 | [context-kit](https://github.com/caty-ai/context-kit) | 面向单个智能体的六件上下文卫生工具组 — 限制大输出、委托简报校验、安全防护、记忆检索、worktree 快照 | 已公开・MIT |
-| 纵轴 | [Persona Engine](https://github.com/caty-ai/persona-engine) | 为智能体赋予人格 — 分层人格与情感渐变 | 已公开・MIT |
+| 纵轴 | [Persona Engine](https://github.com/caty-ai/persona-engine) | 在智能体已有人格之上叠加关系与情感层 | 已公开・MIT |
 | 纵轴 | [Persona Growth Loop](https://github.com/caty-ai/persona-growth-loop) | 让人格本身成长 — 以最小且幂等的提案 | 已公开・MIT |
 | 纵轴 | [X Collector](https://github.com/caty-ai/x-collector) | 把 X 与网络素材汇成每日一份摘要 — 给人也给智能体 | 已公开・MIT |
 | 纵轴 | [Self Growth Loop](https://github.com/caty-ai/self-growth-loop) | 让智能体自我成长的循环 — 提案、治理与采用记录 | 已公开・MIT |

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -435,10 +435,10 @@
       "status": "published",
       "maturity": "product",
       "tagline": {
-        "en": "Gives an agent a persona — layered personality and graded emotion",
-        "ja": "エージェントに人格を与える — 人格レイヤーと感情のグラデーション",
-        "zh": "为智能体赋予人格 — 分层人格与情感渐变",
-        "th": "มอบบุคลิกให้เอเจนต์ — เลเยอร์บุคลิกและอารมณ์แบบไล่ระดับ"
+        "en": "Layers relationship and emotion onto an agent's existing persona",
+        "ja": "エージェントの既存人格に関係と感情のレイヤーを重ねる",
+        "zh": "在智能体已有人格之上叠加关系与情感层",
+        "th": "ซ้อนเลเยอร์ความสัมพันธ์และอารมณ์บนบุคลิกเดิมของเอเจนต์"
       },
       "axis": {
         "group": "vertical",


### PR DESCRIPTION
## Why

The registry (authority order #1) described Persona Engine as **"Gives an agent a persona"**, while the module's canonical README explicitly states the opposite framing: *"Who your agent is … [is] decided by the persona it already has … persona-engine never touches that."* The registry claim was the drifted side.

Found by the org-consistency night lane (OC-E, confidence=high, first seen 2026-08-26). Drift issue: caty-ai/alpha-nightshift-dev#65 (fingerprint `45ee45f5…`).

## What

- `registry/modules.json`: persona-engine `tagline` in all four registry languages, aligned with the README:
  - en: `Layers relationship and emotion onto an agent's existing persona`
  - ja: `エージェントの既存人格に関係と感情のレイヤーを重ねる`
  - zh: `在智能体已有人格之上叠加关系与情感层`
  - th: `ซ้อนเลเยอร์ความสัมพันธ์และอารมณ์บนบุคลิกเดิมของเอเจนต์`
- `README.md` / `README.ja.md` / `README.zh.md` / `README.th.md`: family-table rerender (`tools/render.py`, mechanical)

## Files touched (declared vs diff)

Declared in WIP (alpha-nightshift-dev#65): `registry/modules.json` + 4 README rerenders → diff matches exactly (5 files, 8 insertions, 8 deletions).

## Verification

- `make test` green on `4542022` (selftests, `check_registry.py --offline`, `render.py --check`: "OK — generated content is up to date")
- Content-only registry change: no code paths touched; sibling-repo family footers will be reswept in follow-up mechanical PRs (owner-approved plan, tracked in alpha-nightshift-dev#65)

## Follow-up

After merge: regenerate the `family-footer` block for every published sibling repository (byte-exact weekly check would otherwise go red on the next weekly run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Completion record (L1-7)

- Candidate SHA: `4542022898d97aa55633cd921b27b6bd9b1ad5e8` (= PR head)
- Done when / evidence (all verified 2026-08-29 by Alpha on the candidate SHA):
  - [PASS] Registry tagline no longer contradicts the canonical README — diff shows en/ja/zh/th replaced with the "layers onto existing persona" framing; README primary source: "persona-engine never touches that" (README.md §intro, checked 2026-08-29)
  - [PASS] All four registry languages defined — `tools/check_registry.py --offline`: "schema check: 10 modules" OK (local `make test`, 2026-08-29)
  - [PASS] Generated content in sync — `tools/render.py --check`: "OK — generated content is up to date" (local + CI `family footer` pass)
  - [PASS] CI green — all required checks pass on `4542022` (evidence freshness / family footer / links resolve / publication gate / registry matches reality Linux+macOS / gitleaks / history-check / pr-size); risk-review-gate cleared by roster human label
- Declared files vs diff: declared in WIP (caty-ai/alpha-nightshift-dev#65) = registry/modules.json + 4 README rerenders; diff = exactly those 5 files (+8/−8). Match.
- Implementer: Alpha (Claude Code, content-only S change). Risk review + merge approval: 翔さん (shojikumaru; `risk-reviewed` label, 2026-08-29). Origin of the finding: org-consistency night lane (OC-E), independently verified against primary sources.
- Release: `v0.15.1` annotated tag on the merge commit (release-sync auto-publishes the GitHub Release).
- Previous release: `v0.15.0` (2026-08-28).
- Follow-up (tracked in caty-ai/alpha-nightshift-dev#65): mechanical family-footer resweep PRs to all published sibling repositories.
