### PR TITLE
[HOLD until Epic CP-2] registry: add caty-ai/caty-gateway (#159 prep part)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -382,6 +382,7 @@ Family OS が広がっても、次の6つは変わりません。
 | 横軸・基盤 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 記憶バス — 家族が知っていることを共有する層 | 公開・MIT |
 | 横軸 | [Sitter](https://github.com/caty-ai/sitter) | 委譲したエージェント実行の見張り番 — 監視・証拠の記録・宣言した範囲内でのみ再起動 | 公開・MIT |
 | 横軸 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | 夜間自律保守ループ — deny-by-default の guard の内側で夜のレーンが走り、朝は人間が cherry-pick するだけ | 公開・MIT |
+| 縦軸 | **Caty Gateway** | CatyPhone の PC 側 gateway — 1 行インストールで、手元の PC で動くエージェント（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 互換）とスマホをつなぐ | 公開準備中 |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Every module on this map, with its current state — generated from the same reg
 | Horizontal · foundation | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | The memory bus — how the family shares what it knows | published, MIT |
 | Horizontal | [Sitter](https://github.com/caty-ai/sitter) | Babysits delegated agent runs — watches, keeps evidence, restarts only within declared bounds | published, MIT |
 | Horizontal | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | Nightly autonomous maintenance loop — isolated night lanes behind a deny-by-default guard; humans cherry-pick in the morning | published, MIT |
+| Vertical | **Caty Gateway** | PC-side gateway for CatyPhone — one-line install; pairs your phone with the agent running on your machine (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible) | publication in preparation |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.th.md
+++ b/README.th.md
@@ -382,6 +382,7 @@ flowchart TB
 | แกนนอน · รากฐาน | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | บัสความทรงจำ — ชั้นที่ครอบครัวใช้แบ่งปันสิ่งที่รู้ | เปิดแล้ว・MIT |
 | แกนนอน | [Sitter](https://github.com/caty-ai/sitter) | พี่เลี้ยงของงานที่มอบหมายให้เอเจนต์ — เฝ้าดู เก็บหลักฐาน และรีสตาร์ตเฉพาะในขอบเขตที่ประกาศไว้ | เปิดแล้ว・MIT |
 | แกนนอน | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | ลูปบำรุงรักษาอัตโนมัติยามค่ำคืน — เลนกลางคืนทำงานหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือก cherry-pick | เปิดแล้ว・MIT |
+| แกนตั้ง | **Caty Gateway** | เกตเวย์ฝั่ง PC ของ CatyPhone — ติดตั้งด้วยคำสั่งบรรทัดเดียว เชื่อมโทรศัพท์กับเอเจนต์ที่รันบนเครื่องของคุณ (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible) | กำลังเตรียมเปิด |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -382,6 +382,7 @@ Family OS 这边没有要做的事。不用安装，不用注册账号，也没�
 | 横轴・基座 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | 记忆总线 — 家族共享所知的一层 | 已公开・MIT |
 | 横轴 | [Sitter](https://github.com/caty-ai/sitter) | 替你盯着委派出去的智能体 — 监视、留证、仅在声明范围内重启 | 已公开・MIT |
 | 横轴 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | 夜间自主维护循环 — 在默认拒绝的防护边界内运行夜间通道，早晨由人工挑选合并 | 已公开・MIT |
+| 纵轴 | **Caty Gateway** | CatyPhone 的电脑端网关 — 一行命令安装，把手机与本机运行的智能体（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 兼容）连接起来 | 准备公开中 |
 <!-- family:generated:family-table:end -->
 
 ---

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -68,6 +68,7 @@ flowchart TB
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime・横方向の基盤 | 記憶バス・登録されたスケジュールの期待・check-in・来歴 | 公開・MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime・観測 | ローカルのプロセスと返信の事実・発注試行の証拠・委譲された同一試行の再起動 | 公開・MIT |
 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime・自律運用ループ | 夜間の観測・実装・検証レーン、guard の publish 境界、morning triage | 公開・MIT |
+| [Caty Gateway](https://github.com/caty-ai/caty-gateway) | runtime・スマホ向けインターフェース | スマホとのペアリング、CatyPhone とローカルエージェント backend の間の音声セッション、backend アダプタ（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 互換） | 公開準備中 |
 <!-- family:generated:module-inventory:end -->
 
 この表は [`registry/modules.json`](../registry/modules.json) から生成しています。「公開準備中」のリンクは、いまはまだ開けません。何が存在し、どこに置かれるのかを地図として正直に保つために載せています。

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -68,6 +68,7 @@ The rules layer sits **above** both axes rather than inside either one. It is a 
 | [Family Memory Architecture](https://github.com/caty-ai/family-memory-architecture) | runtime, horizontal infrastructure | the memory bus; registered schedule expectation, check-in, provenance | published, MIT |
 | [Sitter](https://github.com/caty-ai/sitter) | runtime, observation | local process and reply facts, dispatch-attempt evidence, delegated same-attempt restart | published, MIT |
 | [Alpha Nightshift](https://github.com/caty-ai/alpha-nightshift) | runtime, autonomous ops loop | overnight observe/implement/verify lanes, the guard publish boundary, and morning triage | published, MIT |
+| [Caty Gateway](https://github.com/caty-ai/caty-gateway) | runtime, phone-facing interface | phone pairing, the voice session between CatyPhone and a local agent backend, and the backend adapters (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible) | publication in preparation |
 <!-- family:generated:module-inventory:end -->
 
 This table is generated from [`registry/modules.json`](../registry/modules.json). Links marked *publication in preparation* cannot be opened yet. They are listed so the map stays honest about what exists and where it will live.

--- a/docs/readme-visual-system.md
+++ b/docs/readme-visual-system.md
@@ -147,6 +147,7 @@ the generated block directly.
 | Family Memory Architecture | `caty-ai/family-memory-architecture` | published, MIT |
 | Sitter | `caty-ai/sitter` | published, MIT |
 | Alpha Nightshift | `caty-ai/alpha-nightshift` | published, MIT |
+| Caty Gateway | `caty-ai/caty-gateway` | publication in preparation |
 <!-- family:generated:repository-links:end -->
 
 ## Deliberate palette split

--- a/registry/modules.json
+++ b/registry/modules.json
@@ -339,6 +339,21 @@
           "zh": "夜间自主维护——夜间通道在默认拒绝的防护内运行，早晨由人工挑选合并",
           "th": "งานบำรุงรักษาอัตโนมัติยามค่ำคืน — เลนกลางคืนวิ่งหลังการ์ดแบบปฏิเสธโดยปริยาย ตอนเช้ามนุษย์เลือก cherry-pick"
         }
+      },
+      "caty-gateway": {
+        "name": "caty-gateway",
+        "desc": {
+          "en": "The PC-side gateway for CatyPhone: a one-line install that pairs your phone with the agent already running on your machine (Claude Code, Codex CLI, OpenClaw, Hermes, or any OpenAI-compatible server) and carries the conversation by voice",
+          "ja": "CatyPhone の PC 側 gateway。1 行インストールで、手元の PC で動いているエージェント（Claude Code・Codex CLI・OpenClaw・Hermes・OpenAI 互換サーバ）とスマホをペアリングし、声で会話をつなぐ",
+          "zh": "CatyPhone 的电脑端网关：一行命令安装，把手机与本机已在运行的智能体（Claude Code、Codex CLI、OpenClaw、Hermes 或任何 OpenAI 兼容服务）配对，并用语音承载对话",
+          "th": "เกตเวย์ฝั่ง PC ของ CatyPhone: ติดตั้งด้วยคำสั่งบรรทัดเดียว จับคู่โทรศัพท์กับเอเจนต์ที่รันอยู่บนเครื่องของคุณแล้ว (Claude Code, Codex CLI, OpenClaw, Hermes หรือเซิร์ฟเวอร์ที่เข้ากันได้กับ OpenAI) และส่งต่อบทสนทนาด้วยเสียง"
+        },
+        "desc_short": {
+          "en": "PC-side gateway for CatyPhone — one-line install; pairs your phone with the agent on your machine",
+          "ja": "CatyPhone の PC 側 gateway。1 行インストールで、手元のエージェントとスマホをつなぐ",
+          "zh": "CatyPhone 的电脑端网关——一行命令安装，把手机接到本机的智能体",
+          "th": "เกตเวย์ฝั่ง PC ของ CatyPhone — ติดตั้งบรรทัดเดียว เชื่อมโทรศัพท์กับเอเจนต์บนเครื่องของคุณ"
+        }
       }
     }
   },
@@ -623,6 +638,33 @@
         "ja": "夜間の観測・実装・検証レーン、guard の publish 境界、morning triage"
       },
       "footer": true
+    },
+    {
+      "id": "caty-gateway",
+      "name": "Caty Gateway",
+      "repo": "caty-ai/caty-gateway",
+      "status": "preparing",
+      "maturity": "public preview",
+      "tagline": {
+        "en": "PC-side gateway for CatyPhone — one-line install; pairs your phone with the agent running on your machine (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible)",
+        "ja": "CatyPhone の PC 側 gateway — 1 行インストールで、手元の PC で動くエージェント（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 互換）とスマホをつなぐ",
+        "zh": "CatyPhone 的电脑端网关 — 一行命令安装，把手机与本机运行的智能体（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 兼容）连接起来",
+        "th": "เกตเวย์ฝั่ง PC ของ CatyPhone — ติดตั้งด้วยคำสั่งบรรทัดเดียว เชื่อมโทรศัพท์กับเอเจนต์ที่รันบนเครื่องของคุณ (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible)"
+      },
+      "axis": {
+        "group": "vertical",
+        "foundation": false
+      },
+      "license": "MIT",
+      "class": {
+        "en": "runtime, phone-facing interface",
+        "ja": "runtime・スマホ向けインターフェース"
+      },
+      "owns": {
+        "en": "phone pairing, the voice session between CatyPhone and a local agent backend, and the backend adapters (Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI-compatible)",
+        "ja": "スマホとのペアリング、CatyPhone とローカルエージェント backend の間の音声セッション、backend アダプタ（Claude Code / Codex CLI / OpenClaw / Hermes / OpenAI 互換）"
+      },
+      "footer": false
     }
   ],
   "adjacent": [


### PR DESCRIPTION
## Why

Closes the **prep part** of #159: register the upcoming `caty-ai/caty-gateway` (Epic shojikumaru/wip-caty-talk#1187, child 6) in the registry as a `preparing` module so the map, footers and org profile already know where it will live. The execution part (callers, ruleset, REPO-ROLES, label, PVR) waits for the repo to exist (child 1 = wip-caty-talk#1189) and is tracked in #159.

## What changed

- `registry/modules.json` — **surgical text insert only** (no `json.dump` rewrite; diff is +42 lines, nothing reflowed):
  - `modules[]`: `caty-gateway` — `status: preparing`, `axis: vertical`, `footer: false`, tagline ×4 languages
  - `org_profile.modules`: `caty-gateway` — `desc` / `desc_short` ×4 languages
- `README*.md` ×4, `docs/engineering*.md` ×2, `docs/readme-visual-system.md` — regenerated by `tools/render.py` (no hand edits)

### Maturity — owner ruled

`"maturity": "public preview"` — **ruled by owner 2026-09-04** (#159 comment 5542196177); the drafted value stands, no edit needed. The `preparing` → `published` + `footer: true` flip happens at Epic CP-2 (public flip), not in this PR.

## Measured (not assumed)

- selftest published count is **already dynamic** (`tools/selftest_family_footer.py::test_org_ja_intro_uses_counter_for_eleven` counts from the live registry, asserts `>= 11`) → no selftest change needed.
- `caty-ai/.github` needs **no change**: `external-input-watch.yml` has no target list; each repo's caller is event-driven.
- Ruleset actor ids measured from live family-os rulesets 21187519 / 21578000 (Integration 4728478 = repo-state App, Team 18944202 = family-agents).

## Verification (2026-09-04, local, worktree `family-os-wt-159`)

```
make test                      → OK (footer selftest / publication gate 85 assertions / evidence warning / check_registry --offline: 11 modules / render.py --check: up to date)
python3 tools/check_registry.py (online) → OK — every module claim matches the registry
                                          (caty-gateway: declared preparing, GitHub serves PRIVATE/absent → consistent)
```

Expected CI: `family-links` is likely **red** on `docs/engineering*.md` (tokenless lychee cannot open a not-yet-existing repo) — this is the open contradiction #100, not a defect of this PR. All other checks expected green.

## Templates for the execution part

Prepared under workspace `.omc/artifacts/159-caty-gateway-onboarding/` (also pasted into #159): `external-input-caller.yml`, `repo-state-caller.yml` (pinned `v0.17.0`), `ruleset-caty-gateway.json`, `REPO-ROLES-row.md`, owner command list.

## Declared file set (L0-6)

`registry/modules.json`, `README.md`, `README.ja.md`, `README.zh.md`, `README.th.md`, `docs/engineering.md`, `docs/engineering.ja.md`, `docs/readme-visual-system.md`

## Completion record (L1-7) — to be filled at merge time

- Done when (prep part): registry draft PASS / selftest dynamic PASS (measured, no change) / caller templates PASS / ruleset JSON PASS / REPO-ROLES row PASS
- Candidate SHA: (set at review)
- Implementer: alpha (Claude Code) · Reviewers: heterogeneous 3 seats via loom-seats (S/M)
- CI: (set at review)
- risk-reviewed: owner label, head-SHA bound — request only after final head
- release: **`vX.Y.Z` (minor) recommended** — any `modules[]` change obliges the 45-target sibling sweep (#107) and footers list `preparing` modules, so the merge is shipping-equivalent (T-5: annotated tag + GitHub Release). Owner may rule `deferred` with #159 as the LC-1 trigger if the sweep is bundled with the CP-2 flip instead. previous release: v0.17.0 (fulfilled, Release exists)
- Post-merge obligation: sibling sweep via `tools/family_footer.py render-all` (9 siblings × 4 READMEs + org md ×5 with `--org-target`; SVG ×4 untouched) — see alpha-wiki `alpha-nightshift-publication.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

