### PR TITLE
repo-state: refresh latest release fields on every update run (#163)

### DIFF
--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -112,15 +112,11 @@ jobs:
           set -eu
 
           generator="$RUNNER_TEMP/repo-state-gen.sh"
+          # GITHUB_TOKEN-created Releases do not fire the release event.
+          # Query gh api repos/{repo}/releases/latest once per update run (again on rebase retry).
+          # An explicit 404 maps to null; other failures fail the run.
           regenerate() {
-            case "${GITHUB_EVENT_NAME:-}" in
-              release|workflow_dispatch)
-                REPO_STATE_REFRESH_RELEASE=1 "$generator" --stamp-mode auto
-                ;;
-              *)
-                "$generator" --stamp-mode auto
-                ;;
-            esac
+            REPO_STATE_REFRESH_RELEASE=1 "$generator" --stamp-mode auto
           }
 
           regenerate

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -50,7 +50,7 @@ Its schema is [`status.schema.json`](./status.schema.json). Field semantics are:
 | `describes_commit` | Full lowercase 40-character SHA of the nearest ancestor whose commit message does not start with `chore(repo-state):`. |
 | `describes_commit_date` | Committer date of `describes_commit`, in ISO-8601 UTC. |
 | `branch` | Branch whose API HEAD is the comparison target, normally the default branch. |
-| `latest_tag` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, and it is refreshed from GitHub only during an explicit release refresh. |
+| `latest_tag` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, and it is refreshed from GitHub only during an explicit release refresh; the reusable workflow requests that refresh on every `update` run (§4). |
 | `latest_release_url` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, maps to `null` on an explicit GitHub 404 during release refresh, and any other refresh failure is fatal. |
 | `agents_entry` | The stamped agent entry file, exactly `FOR-AGENTS.md` or `AGENTS.md`, or `null` when the repository has neither file. |
 | `canonical_api` | CDN-independent GitHub commits API URL for `repo` and `branch`. |
@@ -85,13 +85,18 @@ not hand reviewers branch-pinned raw URLs and do not use dates as evidence of fr
 The reusable workflow has two jobs. `update` runs for default-branch pushes, published
 releases, and manual dispatches. Push events alone are skipped when the actor is
 `github-actions[bot]` or the organization's stamp app, or the head commit message begins
-`chore(repo-state):`. Release and manual events are never skipped. Push runs preserve the
-existing release fields and do
-not query GitHub releases. Release and manual-dispatch runs check out the default branch
-HEAD, not the release tag, and they refresh release metadata by running
-`repo-state-gen.sh --stamp-mode auto --refresh-release`. An explicit GitHub 404 maps the
+`chore(repo-state):`. Release and manual events are never skipped. Every `update` run
+(push, release, and manual dispatch) refreshes release metadata by running
+`repo-state-gen.sh --stamp-mode auto --refresh-release`, because Releases created with
+`GITHUB_TOKEN` (the family release-sync carrier) do not emit a `release` event.
+Release and manual-dispatch runs still check out the default branch HEAD, not the release
+tag. An explicit GitHub 404 maps the
 release fields to `null`; any other refresh failure fails the run without writing a
 partial update.
+
+Release refresh adds one `gh api repos/{repo}/releases/latest` call per `update` run
+(at most two with the rebase retry), authenticated with `GITHUB_TOKEN`. A non-404 API
+failure now also fails a push stamp run; this is intentionally fail-closed.
 
 An update regenerates deterministic output and exits without a commit when the managed
 files have no diff. Otherwise it commits as `github-actions[bot]` with message

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -50,8 +50,8 @@ Its schema is [`status.schema.json`](./status.schema.json). Field semantics are:
 | `describes_commit` | Full lowercase 40-character SHA of the nearest ancestor whose commit message does not start with `chore(repo-state):`. |
 | `describes_commit_date` | Committer date of `describes_commit`, in ISO-8601 UTC. |
 | `branch` | Branch whose API HEAD is the comparison target, normally the default branch. |
-| `latest_tag` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, and it is refreshed from GitHub only during an explicit release refresh; the reusable workflow requests that refresh on every `update` run (§4). |
-| `latest_release_url` | Carried forward from the existing `status.json` on ordinary runs. It becomes `null` when no prior value exists, maps to `null` on an explicit GitHub 404 during release refresh, and any other refresh failure is fatal. |
+| `latest_tag` | Refreshed from the repository's latest GitHub Release when a release refresh is requested (`--refresh-release` or `REPO_STATE_REFRESH_RELEASE=1`); the reusable workflow requests it on every `update` run (§4). An explicit GitHub 404 (no published, non-prerelease Release) maps it to `null`. Without a refresh request (local runs, `--check`, verify-only) it is carried forward from the existing `status.json`, or `null` when no prior value exists. |
+| `latest_release_url` | Refreshed together with `latest_tag` under the same rule; maps to `null` on an explicit GitHub 404 during release refresh, and any other refresh failure is fatal (no partial update is written). Without a refresh request it is carried forward from the existing `status.json`, or `null` when no prior value exists. |
 | `agents_entry` | The stamped agent entry file, exactly `FOR-AGENTS.md` or `AGENTS.md`, or `null` when the repository has neither file. |
 | `canonical_api` | CDN-independent GitHub commits API URL for `repo` and `branch`. |
 | `canonical_raw` | Immutable raw URL for `status.json` at `describes_commit`. |
@@ -86,8 +86,8 @@ The reusable workflow has two jobs. `update` runs for default-branch pushes, pub
 releases, and manual dispatches. Push events alone are skipped when the actor is
 `github-actions[bot]` or the organization's stamp app, or the head commit message begins
 `chore(repo-state):`. Release and manual events are never skipped. Every `update` run
-(push, release, and manual dispatch) refreshes release metadata by running
-`repo-state-gen.sh --stamp-mode auto --refresh-release`, because Releases created with
+(push, release, and manual dispatch) refreshes release metadata by running the generator with a release refresh requested
+(`REPO_STATE_REFRESH_RELEASE=1 repo-state-gen.sh --stamp-mode auto`; the `--refresh-release` flag is equivalent), because Releases created with
 `GITHUB_TOKEN` (the family release-sync carrier) do not emit a `release` event.
 Release and manual-dispatch runs still check out the default branch HEAD, not the release
 tag. An explicit GitHub 404 maps the
@@ -97,6 +97,7 @@ partial update.
 Release refresh adds one `gh api repos/{repo}/releases/latest` call per `update` run
 (at most two with the rebase retry), authenticated with `GITHUB_TOKEN`. A non-404 API
 failure now also fails a push stamp run; this is intentionally fail-closed.
+A Release created after the last default-branch push is picked up by the next `update` run; until then the stamp carries the previous Release (tracked in [#165](https://github.com/caty-ai/family-os/issues/165)).
 
 An update regenerates deterministic output and exits without a commit when the managed
 files have no diff. Otherwise it commits as `github-actions[bot]` with message

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -473,6 +473,49 @@ EOF
     printf '%s\n' 'refresh-release env flag: ok'
 }
 
+test_refresh_release_replaces_stale_existing_tag() {
+    local repo mock_dir
+    repo=$(new_repo FOR-AGENTS.md)
+    run_gen "$repo" > /dev/null
+    seed_release_fields "$repo" 'v1.2.3' 'https://github.com/fixture/repo/releases/tag/v1.2.3'
+    mock_dir=$(mktemp -d "$TEST_TMP/mock-refresh-stale.XXXXXX")
+    cat > "$mock_dir/gh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [[ "${1-}" == api && "${2-}" == repos/fixture/repo/releases/latest ]]; then
+    printf 'v1.3.0\thttps://github.com/fixture/repo/releases/tag/v1.3.0\n'
+    exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 98
+EOF
+    chmod +x "$mock_dir/gh"
+
+    PATH="$mock_dir:$PATH" REPO_STATE_GH_BIN="$mock_dir/gh" REPO_STATE_NO_GH=0 REPO_STATE_REFRESH_RELEASE=1 run_gen "$repo" > /dev/null
+
+    assert_eq 'v1.3.0' "$(jq -r '.latest_tag' "$repo/status.json")" 'release refresh did not replace stale latest_tag'
+    assert_eq 'https://github.com/fixture/repo/releases/tag/v1.3.0' "$(jq -r '.latest_release_url' "$repo/status.json")" \
+        'release refresh did not replace stale latest_release_url'
+    run_gen "$repo" --check > /dev/null
+    printf '%s\n' 'refresh-release over stale existing tag: ok'
+}
+
+test_workflow_refreshes_release_on_every_update_run() {
+    local workflow="$ROOT_DIR/.github/workflows/repo-state.yml"
+    grep -Fq 'REPO_STATE_REFRESH_RELEASE=1 "$generator" --stamp-mode auto' "$workflow" \
+        || fail 'workflow does not request release refresh'
+    if grep -nE '^[[:space:]]*"\$generator" --stamp-mode auto' "$workflow"; then
+        fail 'workflow invokes generator without release refresh'
+    fi
+    if grep -Fn 'release|workflow_dispatch)' "$workflow"; then
+        fail 'workflow retains the old release refresh event gate'
+    fi
+    if grep -Fn 'do not query GitHub releases' "$ROOT_DIR/docs/repo-state/spec.md"; then
+        fail 'spec retains the old push release query contract'
+    fi
+    printf '%s\n' 'workflow refresh contract: every update run refreshes releases'
+}
+
 test_refresh_release_404_maps_null() {
     local repo mock_dir git_marker
     repo=$(new_repo FOR-AGENTS.md)
@@ -587,6 +630,8 @@ test_normal_run_without_gh_on_path
 test_refresh_release_without_gh_on_path_fails
 test_refresh_release_flag_queries_gh
 test_refresh_release_env_queries_gh
+test_refresh_release_replaces_stale_existing_tag
+test_workflow_refreshes_release_on_every_update_run
 test_refresh_release_404_maps_null
 test_refresh_release_transport_error_is_fatal
 test_refresh_release_http_error_is_fatal

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -502,16 +502,34 @@ EOF
 
 test_workflow_refreshes_release_on_every_update_run() {
     local workflow="$ROOT_DIR/.github/workflows/repo-state.yml"
-    grep -Fq 'REPO_STATE_REFRESH_RELEASE=1 "$generator" --stamp-mode auto' "$workflow" \
-        || fail 'workflow does not request release refresh'
-    if grep -nE '^[[:space:]]*"\$generator" --stamp-mode auto' "$workflow"; then
-        fail 'workflow invokes generator without release refresh'
+    local body
+    body=$(mktemp "$TEST_TMP/regenerate.XXXXXX")
+    awk '
+        /^[[:space:]]*regenerate\(\) \{/ { found = 1; next }
+        found && /^[[:space:]]*\}/ { closed = 1; exit }
+        found { print }
+        END { if (!found || !closed) exit 1 }
+    ' "$workflow" > "$body" || fail 'workflow regenerate function not found or unclosed'
+    [[ -s "$body" ]] || fail 'workflow regenerate function is empty'
+
+    assert_eq 1 "$(grep -Fc '"$generator"' "$body" || true)" \
+        'workflow regenerate must invoke the generator exactly once'
+    grep -Eq '^[[:space:]]*(REPO_STATE_REFRESH_RELEASE=1 "\$generator" --stamp-mode auto|"\$generator" --stamp-mode auto --refresh-release)[[:space:]]*$' "$body" \
+        || fail 'workflow regenerate does not unconditionally request release refresh'
+    if grep -nE 'case|if |GITHUB_EVENT_NAME|REFRESH_RELEASE=0|event_name' "$body"; then
+        fail 'workflow regenerate contains conditional release refresh'
     fi
-    if grep -Fn 'release|workflow_dispatch)' "$workflow"; then
-        fail 'workflow retains the old release refresh event gate'
+
+    assert_eq 1 "$(grep -Fc -- '--stamp-mode auto' "$workflow" || true)" \
+        'workflow must have exactly one auto generation call site'
+    if grep -F -- '--stamp-mode auto' "$workflow" | grep -nvE 'REPO_STATE_REFRESH_RELEASE=1|--refresh-release'; then
+        fail 'workflow invokes auto generation without release refresh'
     fi
-    if grep -Fn 'do not query GitHub releases' "$ROOT_DIR/docs/repo-state/spec.md"; then
-        fail 'spec retains the old push release query contract'
+
+    grep -Fq '"$RUNNER_TEMP/repo-state-gen.sh" --check' "$workflow" \
+        || fail 'workflow does not invoke check mode'
+    if grep -F -- '--check' "$workflow" | grep -n 'refresh'; then
+        fail 'workflow check mode requests release refresh'
     fi
     printf '%s\n' 'workflow refresh contract: every update run refreshes releases'
 }


### PR DESCRIPTION
## Why

`status.json.latest_tag` / `latest_release_url` were only refreshed from `repos/{repo}/releases/latest` when the reusable workflow ran on `release` or `workflow_dispatch`. Every family Release is created by the release-sync carrier (`family-dev-handbook/.github/workflows/reusable-release-sync.yml@ci-v1`) with `GITHUB_TOKEN`, and GitHub never emits `release: published` for `GITHUB_TOKEN`-created events, so the refresh gate never fired. The stamp silently drifted after every release (persona-engine kept `v0.2.5` for hours after `v0.2.6` shipped; see #163).

This is fix option (1) from #163: refresh on every `update` run.

## What changed

- `.github/workflows/repo-state.yml` — `regenerate()` always runs the pinned generator with `REPO_STATE_REFRESH_RELEASE=1` (the `release|workflow_dispatch` case gate is gone; a 3-line comment records why). The `pull_request` `check` job is untouched and still only runs `--check` (never queries releases; fork PRs with read-only tokens unaffected).
- `docs/repo-state/spec.md` — §4: every `update` run (push, release, manual dispatch) refreshes release metadata; the "Push runs preserve the existing release fields and do not query GitHub releases" contract is removed. New paragraph names the cost (one `gh api` call per run, at most two with the rebase retry, `GITHUB_TOKEN`) and that a non-404 API failure now fails a push stamp run (fail-closed, consistent with the reader protocol in §3: stale stamps are the safe direction). §2 `latest_tag` / `latest_release_url` rows: refreshed when a release refresh is requested (env or flag), which the workflow does on every `update` run; 404 → `null`; carried forward only without a request (local, `--check`, verify-only). §4 also records the remaining window after a release-sync Release (tracked in #165).
- `tools/selftest_repo_state_gen.sh` — two new tests: `test_refresh_release_replaces_stale_existing_tag` (existing status.json seeded with `v1.2.3`, mocked `releases/latest` answers `v1.3.0`, regenerated stamp carries `v1.3.0` and `--check` stays green) and `test_workflow_refreshes_release_on_every_update_run` (structural contract over the yml: the `regenerate()` body has exactly one generator call in a refresh-requesting form and no conditional; every `--stamp-mode auto` line requests a refresh; the `check` job runs only `--check`).
- `tools/repo-state-gen.sh` — **unchanged**. The explicit `REPO_STATE_REFRESH_RELEASE` / `--refresh-release` switch stays (default 0), so local and verify-only runs remain deterministic and gh-free; `test_release_fields_preserved_without_refresh` keeps its meaning.

Not in this PR (deferred on purpose): the `@v0.12.1` example pins in the workflow header comment and `repo-state-caller.yml`, plus every caller's pin bump. Those move to the new tag after this PR is released.

## Named cost / risk (shown to every seat)

- +1 authenticated `gh api repos/{repo}/releases/latest` call per `update` run (≤ 2 with the rebase retry), using `GITHUB_TOKEN`. `releases/latest` returns the newest non-draft, non-prerelease Release, which matches what release-sync publishes (it only passes `--prerelease` for SemVer prerelease tags).
- A non-404 API failure (transport / 5xx / rate-limit) now fails a push stamp run. Previously push runs never touched the API. Accepted as fail-closed: a missing stamp is detected by readers via SHA mismatch (spec §3), and the weekly audit reads the caller-run conclusion.
- Fork PR `check` job: unchanged, never refreshes.

## Files touched (L0-6)

Declared in the WIP comment on #163: `.github/workflows/repo-state.yml`, `docs/repo-state/spec.md`, `tools/selftest_repo_state_gen.sh`. `git diff --stat origin/main...0d69970` lists exactly those three files. No file outside the declared set.

## Review

Round 1 on `a4ecac0` (blind, same brief, read-only; requested = actual model):

| seat | effort | verdict | findings |
|---|---|---|---|
| GLM 5.3 (`glm` CLI) | medium-high, suite executed | GO | MINOR: contract test is literal-string, could stay green if the line survives behind a computed value. MINOR: push run concurrent with Release creation stamps the previous Release (self-heals next run). NIT: §2 `latest_tag` "only" clause vs new behavior. NIT: pins deferred. |
| Opus 5 (code-reviewer subagent) | high | GO-with-fixes | MAJOR: window remains — release-sync creates the Release on a tag push the caller never listens to, so `latest_tag` lags until the next main push. MAJOR: contract test passes against `=0` on push / `=1` otherwise (reproduced). MAJOR: fail-closed on push sacrifices the SHA stamp on a transient API blip. MINOR ×3: `latest_tag` row lacks 404→null; spec says flag, workflow uses env; "ordinary runs" misleading. NIT ×2. |
| Grok 4.6 (`grok` CLI, substitute for Kimi K3) | high | GO | MINOR: spec flag vs env form; contract test would miss a `=0` on push split. MINOR: stale-tag test proves generator overwrite, not the workflow gate. NIT: DESIGN.md (frozen) still describes the old rule. |

Arbitration (evidence, not seat count):

- **Fixed in delta `0d69970`** (3-seat convergence): the contract test is now structural — it extracts the `regenerate()` body, requires exactly one generator call in env or flag refresh form, rejects any `case` / `if` / `GITHUB_EVENT_NAME` / `REFRESH_RELEASE=0`, requires every `--stamp-mode auto` line in the file to request a refresh, and asserts the `check` job runs only `--check`. Ad-hoc mutation (`=0` on push, `=1` otherwise) is rejected; current env form and the flag form pass. Spec §2 rows rewritten (refresh request, 404→null for both fields, carry-forward without a request); §4 names the actual invocation.
- **Accepted, tracked in #165** (Opus MAJOR-1): option (1) closes the permanent drift but a release with no later main push still lags one release. Real, and outside option (1)'s scope; #165 lists the closing options (caller `workflow_run` on release-sync, tag push, app token in release-sync). §4 now states the window.
- **Kept fail-closed** (Opus MAJOR-3 dissent recorded): GLM and Grok argued from spec §3 that carrying stale release fields into a fresh-SHA stamp is the original silent-drift shape, while a red run is visible in the weekly audit and the unstamped HEAD is the safe direction for readers. Owner may override at merge time.
- DESIGN.md is the frozen design record and stays as-is (Grok NIT).

Delta r1 verification by Opus 5 (the seat that raised the MAJORs), on `0d69970`: **cumulative GO**. Its round-1 mutation (`=0` on push / `=1` otherwise) now fails on two independent assertions (call count and conditional-token reject); a subtler variant (`refresh=1` flipped by a test, then `REPO_STATE_REFRESH_RELEASE="$refresh"`) also fails the real suite. MAJOR-2 and the three spec MINORs fixed; MAJOR-1 deferral to #165 accepted; MAJOR-3 arbitration accepted by the seat ("do not reopen on my account"; if #165 lands, revisit `GH_HTTP_TIMEOUT=5` with no retry as the flake surface). Three non-blocking NITs on the new test recorded in the seat file; none holds the merge.

Alpha (Claude Fable 5.1) wrote the brief, delegated the diff to Codex, and arbitrates; Alpha is not counted as a seat. Seat composition from `loom-seats --size M --absent kimi-k3` (Kimi K3: weekly quota exhausted, 403 at 2026-09-05 02:30Z).

correlated-seats record (L1-10, Opus 5 shares the Claude lineage with the orchestrator): scope = this PR only / pair = Opus 5 ↔ Alpha (Fable 5.1, orchestrator, not a seat) / reason = roster panel for size M; writer is Codex, not Claude / approved_by = Sho (review_council 2026-08-21 roster decision) / date = 2026-09-05 / writer condition = writer must be Codex (holds: implementation by Codex gpt-6-astra).

Tracked in #163 — this PR alone does not satisfy the third Done-when item (tag + caller bumps), so #163 stays open until the Release and the caller pin lane finish.

## 完了記録 (Completion record)

candidate SHA: 0d69970df362a3b615b9efef605bc43847e3db68 (round-1 head a4ecac0 + review delta)
implementer: Codex (gpt-6-astra, medium) via `codex exec`, brief by Alpha
reviewer: GLM 5.3 / Opus 5 (code-reviewer subagent) / Grok 4.6 — independent read-only seats, same blind brief
identity check: 別モデル (writer Codex ≠ every seat; orchestrator Alpha not a seat)
CI: green on 0d69970 (2026-09-05) — test-lint test/lint/test-macos, repo-state check, gitleaks, history-check, pr-size, risk-review-gate, family footer, publication gate, links, registry all pass; run https://github.com/caty-ai/family-os/actions/runs/33945342824 (test-lint) and https://github.com/caty-ai/family-os/actions/runs/33945342677 (repo-state check). Conditional jobs (audit issue opener, size-exempt strip, macOS skip variant, update job on PR) skipped by design.
release: v0.18.0 (minor — behaviour of the reusable workflow changes for every caller; annotated tag on the squash-merge commit + GitHub Release via release-sync; then callers bump `uses:` + `generator_ref` in a separate lane)
previous release: v0.17.0 → https://github.com/caty-ai/family-os/releases/tag/v0.17.0 (Latest, 2026-09-01, fulfilled). The one merge in between (#162, `b222989`) declared `release: N/A ③`.

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| A `push`-event run of repo-state regenerates `latest_tag` / `latest_release_url` from the live latest Release | PASS (by construction + contract test) | `regenerate()` in `.github/workflows/repo-state.yml` now reads `REPO_STATE_REFRESH_RELEASE=1 "$generator" --stamp-mode auto` unconditionally; `test_workflow_refreshes_release_on_every_update_run` asserts it (`bash tools/selftest_repo_state_gen.sh` → `workflow refresh contract: every update run refreshes releases`, 2026-09-05). Live push-run confirmation on a caller happens after the tag exists (callers pin tags; a `@branch` reference is not allowed by the pin rule), and is recorded on #163 when the first caller bumps. |
| selftest covers "existing status.json has an older tag; latest Release is newer → regenerated stamp carries the newer tag" | PASS | `test_refresh_release_replaces_stale_existing_tag`: seeded `v1.2.3`, mock `releases/latest` → `v1.3.0`; output line `refresh-release over stale existing tag: ok`; full run ends `selftest_repo_state_gen: ok` (2026-09-05). |
| Tagged so callers can bump; note in caller template | PENDING until merge | Declared `release: v0.18.0` above; tag + Release after squash merge; caller pin bumps in a separate lane (recorded on #163). |

### Verification (local, 2026-09-05, worktree at 0d69970)

```
$ bash tools/selftest_repo_state_gen.sh | tail -8
refresh-release over stale existing tag: ok
workflow refresh contract: every update run refreshes releases
refresh-release 404: null as expected
refresh-release transport failure: red as expected
refresh-release HTTP failure: red as expected
freshness contract literal: aligned
repo-state citations: clean
selftest_repo_state_gen: ok

$ make test | tail -2
OK — every module claim matches the registry.
OK — generated content is up to date.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
