### PR TITLE
gate: adopt handbook template v0.28.0 (scan_views string-escape decode) + shipped-rule canaries (#164)

### DIFF
--- a/tools/check_publication_gate.py
+++ b/tools/check_publication_gate.py
@@ -1149,6 +1149,141 @@ def selftest_shipped_denylist():
         and wsl_drvfs_user_path.search(wsl_lowercase_leak) is not None,
         "shipped wsl-drvfs-user-path complements case-sensitive rules",
     )
+    absolute_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\\u002fUs" + "ers\\u002falice"},
+            rules,
+            absolute_string_escape_failures,
+        )
+        == 1
+        and absolute_string_escape_failures
+        == ["denylist: esc.txt:1 contains absolute-personal-path (decoded view)"],
+        "shipped absolute-personal-path string-escape scan finding",
+    )
+    nested_php_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\"\\\"\\\\\\/Us" + "ers\\\\\\/alice\\\"\""},
+            rules,
+            nested_php_string_escape_failures,
+        )
+        == 1
+        and nested_php_string_escape_failures
+        == ["denylist: esc.txt:1 contains absolute-personal-path (decoded view)"],
+        "shipped absolute-personal-path nested serialisation PHP json_encode",
+    )
+    nested_unicode_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\\u005cu002fUs" + "ers\\u005cu002falice"},
+            rules,
+            nested_unicode_string_escape_failures,
+        )
+        == 1
+        and nested_unicode_string_escape_failures
+        == ["denylist: esc.txt:1 contains absolute-personal-path (decoded view)"],
+        "shipped absolute-personal-path nested serialisation unicode backslash",
+    )
+    nested_backslash_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\\\\u002fUs" + "ers\\\\u002falice"},
+            rules,
+            nested_backslash_string_escape_failures,
+        )
+        == 1
+        and nested_backslash_string_escape_failures
+        == ["denylist: esc.txt:1 contains absolute-personal-path (decoded view)"],
+        "shipped absolute-personal-path nested serialisation double backslash",
+    )
+    absolute_solidus_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\\/Us" + "ers\\/alice"},
+            rules,
+            absolute_solidus_escape_failures,
+        )
+        == 1
+        and absolute_solidus_escape_failures
+        == ["denylist: esc.txt:1 contains absolute-personal-path (decoded view)"],
+        "shipped absolute-personal-path solidus-escape scan finding",
+    )
+    wsl_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\\u002fmn" + "t\\u002fc\\u002fusers\\u002falice"},
+            wsl_rules,
+            wsl_string_escape_failures,
+        )
+        == 1
+        and wsl_string_escape_failures
+        == ["denylist: esc.txt:1 contains wsl-drvfs-user-path (decoded view)"],
+        "shipped wsl-drvfs-user-path string-escape scan finding",
+    )
+    wsl_backslash_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\\u005cmn" + "t\\u005cc\\u005cusers\\u005calice"},
+            wsl_rules,
+            wsl_backslash_escape_failures,
+        )
+        == 1
+        and wsl_backslash_escape_failures
+        == ["denylist: esc.txt:1 contains wsl-drvfs-user-path (decoded view)"],
+        "shipped wsl-drvfs-user-path backslash string-escape scan finding",
+    )
+    windows_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "C:\\u005cUs" + "ers\\u005calice"},
+            windows_rules,
+            windows_string_escape_failures,
+        )
+        == 1
+        and windows_string_escape_failures
+        == ["denylist: esc.txt:1 contains windows-user-path (decoded view)"],
+        "shipped windows-user-path string-escape scan finding",
+    )
+    string_escape_clean_failures = []
+    path_rules = rules + windows_rules + wsl_rules
+    _selftest_check(
+        check_denylist(
+            {
+                "placeholder.txt": "\\u002fhome\\u002f<user>\\u002fproject",
+                "url.txt": "https:\\/\\/api.github.com\\/users\\/alice",
+                "regex.txt": "regex: [\\\\/]mn" + "t[\\\\/]+",
+                "i18n.txt": "\\u00e9\\u00e8 caf\\u00e9",
+                "usr.txt": "\\u002fusr\\u002flocal\\u002fbin",
+                "etc.txt": "\\u002fetc\\u002fhosts",
+                "emoji.txt": "\\ud83d\\ude00 emoji only",
+                "unc.txt": "\\\\\\\\server\\\\share",
+            },
+            path_rules,
+            string_escape_clean_failures,
+        )
+        == 0
+        and string_escape_clean_failures == [],
+        "shipped path rules string-escape clean controls",
+    )
+    mixed_separator = "/Us" + "ers\\alice/project"
+    _selftest_check(
+        absolute_personal_path.search(mixed_separator) is None
+        and windows_user_path.search(mixed_separator) is None
+        and wsl_drvfs_user_path.search(mixed_separator) is None,
+        "shipped path rules recorded miss: mixed separator (decided in #164, not widened)",
+    )
+    depth_boundary_failures = []
+    _selftest_check(
+        check_denylist(
+            {"esc.txt": "\\\\\\\\u002fUs" + "ers\\\\\\\\u002falice"},
+            rules,
+            depth_boundary_failures,
+        )
+        == 0
+        and depth_boundary_failures == [],
+        "shipped absolute-personal-path string-escape depth boundary (four layers, documented miss)",
+    )
 
 
 def selftest_scanners():
@@ -2583,7 +2718,7 @@ def selftest_end_to_end():
         )
         _selftest_check(
             result.returncode == 0
-            and "PASS (publication gate selftest; assertions: 190)" in result.stdout
+            and "PASS (publication gate selftest; assertions: 201)" in result.stdout
             and "skip: selftest_shipped_denylist" not in result.stdout,
             "real-root copy-probe runs shipped-denylist selftest: %r" % result.stdout,
         )

--- a/tools/check_publication_gate.py
+++ b/tools/check_publication_gate.py
@@ -76,8 +76,50 @@ def language_of(path):
     return match.group("lang") if match else "en"
 
 
+STRING_ESCAPE = re.compile(
+    r"\\u([dD][89AaBb][0-9A-Fa-f]{2})\\u([dD][c-fC-F][0-9A-Fa-f]{2})"
+    r"|\\u([0-9A-Fa-f]{4})"
+    r"|\\U([0-9A-Fa-f]{8})"
+    r"|\\x([0-9A-Fa-f]{2})"
+    r"|\\/"
+)
+
+
+def decode_string_escapes(text):
+    """Decode path-relevant JSON/YAML escapes once, without tokenizing strings.
+
+    Backslash, quote, newline/tab, octal, named, and null escapes stay verbatim:
+    path rules already tolerate repeated backslashes and do not depend on quotes
+    or controls. Nested serialisation (JSON in JSON, ``\\\\u002f``, ``\\u002f``)
+    is resolved by the bounded rounds in :func:`scan_views`; depth beyond three
+    rounds is the documented boundary.
+    """
+
+    def replace(match):
+        if match.group(1) is not None:
+            high = int(match.group(1), 16)
+            low = int(match.group(2), 16)
+            return chr(0x10000 + ((high - 0xD800) << 10) + low - 0xDC00)
+        if match.group(3) is not None:
+            value = int(match.group(3), 16)
+            return match.group(0) if 0xD800 <= value <= 0xDFFF else chr(value)
+        if match.group(4) is not None:
+            value = int(match.group(4), 16)
+            if value > 0x10FFFF or 0xD800 <= value <= 0xDFFF:
+                return match.group(0)
+            return chr(value)
+        if match.group(5) is not None:
+            return chr(int(match.group(5), 16))
+        return "/"
+
+    return STRING_ESCAPE.sub(replace, text)
+
+
 def scan_views(text):
-    """Return raw plus iterative percent/HTML-decoded views."""
+    """Return raw plus iterative percent/HTML-decoded views, then up to three
+    string-escape rounds per view (``\\uXXXX``, ``\\UXXXXXXXX``, ``\\xHH``,
+    ``\\/``), stopping at the fixed point — #77.
+    """
     views = [text]
     current = text
     for _ in range(3):
@@ -90,6 +132,15 @@ def scan_views(text):
         if unescaped == current:
             break
         current = unescaped
+    for view in tuple(views):
+        current = view
+        for _ in range(3):
+            decoded = decode_string_escapes(current)
+            if decoded == current:
+                break
+            if decoded not in views:
+                views.append(decoded)
+            current = decoded
     return tuple(views)
 
 
@@ -401,10 +452,7 @@ def _nested_personal_urls(candidate, account_slug):
             next_marker = next(marker_indexes, None)
         if character in split_characters:
             previous_split = index
-    repo_name = _personal_url(candidate, account_slug)
-    if repo_name is not False and unseen(repo_name):
-        yield repo_name
-    field_end = 0
+    field_end = -1
     for start in range(len(candidate)):
         if start not in starts:
             continue
@@ -1126,6 +1174,7 @@ def selftest_scanners():
         )
         field_end = -1
         matches = set()
+        reported = set()
         for start in sorted(starts):
             if field_end < start:
                 field_end = start
@@ -1133,6 +1182,14 @@ def selftest_scanners():
                     field_end += 1
             repo_name = _personal_url(candidate[start:field_end], account_slug)
             if repo_name is not False:
+                name = (
+                    account_slug
+                    if repo_name is None
+                    else account_slug + "/" + repo_name
+                ).casefold()
+                if name in reported:
+                    continue
+                reported.add(name)
                 matches.add(repo_name)
         return matches
 
@@ -1143,6 +1200,126 @@ def selftest_scanners():
         check_denylist(documents, rules, failures) == 1
         and "(decoded view)" in failures[0],
         "decoded denylist marker",
+    )
+    unicode_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private\\u002dmarker\n"}, rules, unicode_escape_failures
+        )
+        == 1
+        and "(decoded view)" in unicode_escape_failures[0],
+        "string-escape unicode denylist marker",
+    )
+    long_unicode_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private\\U0000002dmarker\n"},
+            rules,
+            long_unicode_escape_failures,
+        )
+        == 1
+        and "(decoded view)" in long_unicode_escape_failures[0],
+        "string-escape long-unicode denylist marker",
+    )
+    hex_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private\\x2dmarker\n"}, rules, hex_escape_failures
+        )
+        == 1
+        and "(decoded view)" in hex_escape_failures[0],
+        "string-escape hex denylist marker",
+    )
+    wrapped_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private%5Cu002dmarker\n"}, rules, wrapped_escape_failures
+        )
+        == 1
+        and "(decoded view)" in wrapped_escape_failures[0],
+        "string-escape percent-wrapped denylist marker",
+    )
+    entity_wrapped_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "private&#92;u002dmarker\n"},
+            rules,
+            entity_wrapped_escape_failures,
+        )
+        == 1
+        and "(decoded view)" in entity_wrapped_escape_failures[0],
+        "string-escape entity-wrapped denylist marker",
+    )
+    escape_line_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "safe\\u000aprivate\\u002dmarker\n"},
+            rules,
+            escape_line_failures,
+        )
+        == 1
+        and escape_line_failures
+        == ["denylist: README.md:2 contains private marker (decoded view)"],
+        "string-escape decoded-view line number",
+    )
+    surrogate_neighbour_failures = []
+    _selftest_check(
+        check_denylist(
+            {"README.md": "\\ud83d\\ude00 private\\u002dmarker"},
+            rules,
+            surrogate_neighbour_failures,
+        )
+        == 1
+        and "(decoded view)" in surrogate_neighbour_failures[0],
+        "string-escape surrogate pair preserves neighbouring match",
+    )
+    _selftest_check(
+        "😀" in scan_views("\\ud83d\\ude00"),
+        "string-escape surrogate pair combines",
+    )
+    lone_surrogate_views = scan_views("\\ud83d x")
+    _selftest_check(
+        "\\ud83d x" in lone_surrogate_views
+        and not any(
+            0xD800 <= ord(character) <= 0xDFFF
+            for view in lone_surrogate_views
+            for character in view
+        ),
+        "string-escape lone surrogate remains verbatim",
+    )
+    _selftest_check(
+        scan_views("\\U7FFFFFFF \\udc00 \\ud83d")
+        == ("\\U7FFFFFFF \\udc00 \\ud83d",),
+        "string-escape invalid code points remain verbatim",
+    )
+    _selftest_check(
+        scan_views("\\U002f") == ("\\U002f",),
+        "string-escape short uppercase escape remains verbatim",
+    )
+    _selftest_check(
+        scan_views("plain text") == ("plain text",),
+        "string-escape plain text view dedup",
+    )
+    _selftest_check(
+        "-" in scan_views("\\u005cu002d"),
+        "string-escape nested serialisation fixed point",
+    )
+    _selftest_check(
+        "-" in scan_views("\\u005cu005cu002d"),
+        "string-escape three rounds suffice",
+    )
+    _selftest_check(
+        "-" not in scan_views("\\u005cu005cu005cu002d"),
+        "string-escape depth boundary",
+    )
+    _selftest_check(
+        scan_views("\\u005cu005cu005cu002d")[-1] == "\\u002d",
+        "string-escape depth boundary last view",
+    )
+    _selftest_check(
+        scan_views("private%2Dmarker")[:2]
+        == ("private%2Dmarker", "private-marker"),
+        "string-escape existing view order",
     )
     raw_line_failures = []
     _selftest_check(
@@ -1564,6 +1741,10 @@ def selftest_scanners():
         "https://example.org/?u=neutral-owner.github." "io/page",
         "https://example.org/?u=notgithub." "com/neutral-owner/nope",
         "https://example.org/?u=github." "com/neutral-owner/one&b=github." "com/neutral-owner/two",
+        "github." "com/neutral-owner/repo&x=1",
+        "github." "com/neutral-owner&x=1",
+        "github." "com/neutral-owner=1",
+        "github." "com/neutral-owner/Repo?x=github." "com/neutral-owner/repo",
     )
     for candidate in nested_reference_cases:
         _selftest_check(
@@ -1571,6 +1752,54 @@ def selftest_scanners():
             == reference_nested_personal_urls(candidate, "neutral-owner"),
             "nested boundary walk matches reference: %s" % candidate,
         )
+    _selftest_check(
+        set(
+            _nested_personal_urls(
+                "github." "com/neutral-owner/repo&x=1", "neutral-owner"
+            )
+        )
+        == {"repo"},
+        "nested bare-ampersand repository name is field-cut",
+    )
+    _selftest_check(
+        set(
+            _nested_personal_urls(
+                "github." "com/neutral-owner&x=1", "neutral-owner"
+            )
+        )
+        == {None},
+        "nested bare-ampersand account profile is field-cut",
+    )
+    ampersand_registry = _fixture_registry()
+    ampersand_registry["modules"].append(
+        {"name": "Repo", "repo": "neutral-owner/repo", "status": "published"}
+    )
+    ampersand_allowlisted_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "github." "com/neutral-owner/repo&x=1\n"},
+            "neutral-owner",
+            ampersand_registry,
+            ampersand_allowlisted_failures,
+        )
+        == 1
+        and ampersand_allowlisted_failures == [],
+        "registry allowlist matches ampersand-cut repository name",
+    )
+    ampersand_unregistered_failures = []
+    _selftest_check(
+        check_personal_urls(
+            {"README.md": "github." "com/neutral-owner/other&x=1\n"},
+            "neutral-owner",
+            ampersand_registry,
+            ampersand_unregistered_failures,
+        )
+        == 1
+        and len(ampersand_unregistered_failures) == 1
+        and "unknown repository neutral-owner/other"
+        in ampersand_unregistered_failures[0],
+        "unregistered ampersand-cut repository stays red",
+    )
     two_repo_registry = _fixture_registry()
     two_repo_registry["modules"].extend(
         (
@@ -2354,7 +2583,7 @@ def selftest_end_to_end():
         )
         _selftest_check(
             result.returncode == 0
-            and "PASS (publication gate selftest; assertions: 165)" in result.stdout
+            and "PASS (publication gate selftest; assertions: 190)" in result.stdout
             and "skip: selftest_shipped_denylist" not in result.stdout,
             "real-root copy-probe runs shipped-denylist selftest: %r" % result.stdout,
         )


### PR DESCRIPTION
Tracked in #164 (leaves #164 open until the MERGED comment with the tag URL lands)

## What

Re-copy `tools/check_publication_gate.py` from caty-ai/family-dev-handbook **v0.28.0** (PR family-dev-handbook#156, closes handbook#154 — `STRING_ESCAPE` / `decode_string_escapes` + up to three fixed-point string-escape rounds per view in `scan_views`, frozen from x-collector v0.3.3), re-apply the two local hunks from PR #162 on top, and add string-escape canaries + a clean-control block for this repo's **shipped** rules (`absolute-personal-path` / `windows-user-path` / `wsl-drvfs-user-path`) next to the #149 block. No caller change: `family-links.yml` already passes `--registry registry/modules.json`. `.publication-denylist` untouched.

Two commits: `afabe91` (step 1 — mechanical re-copy + local hunks, by Alpha) and `9eb1add` (step 3 — shipped-rule canaries, Codex sol).

## Re-applied local hunks (repeat this on the next re-copy)

Base template blob after `git -C <handbook> show v0.28.0:templates/publication-gate/check_publication_gate.py > tools/check_publication_gate.py` = `c0831bf9e4166e63ffc92bfe3c847b68df9a1b59` (`git hash-object`; previous template v0.24.0 = `9bcb44d0…`).

Local patch = `diff -u <handbook v0.24.0 template> <origin/main 87fb556 tools/check_publication_gate.py>` (259 lines, 2 hunks). Applied with `patch -p0` — both hunks applied cleanly against v0.28.0 at the new offsets:

| hunk (vs v0.24.0) | content | lands at (v0.28.0 + local) |
|---|---|---|
| `@@ -885,7 +885,224 @@` | `selftest_shipped_denylist()` (#149 block) inserted before `selftest_scanners` | L937 |
| `@@ -2123,12 +2340,30 @@` | e2e copy-probe (`PUBLICATION_GATE_SELFTEST_COPY_PROBE`) additions at the end of `selftest_end_to_end` + `run_selftests` tuple entry | L2553–2595 |

**Hand-adjusted literal** (not covered by the patch): the copy-probe child assertion count `"PASS (publication gate selftest; assertions: 165)"` → **`190`** after step 1 (template 166 + local 24) → **`201`** after step 3 (+11 shipped-rule canaries). The first `--selftest` run after the raw patch failed exactly here (intended tripwire).

**New in this lane = third hunk to repeat on the next re-copy**: the 11 `_selftest_check` calls appended at the end of `selftest_shipped_denylist` (L1152–L1286; messages `shipped absolute-personal-path string-escape scan finding` … `shipped absolute-personal-path string-escape depth boundary (four layers, documented miss)`). On the next re-copy, regenerate the local patch as `diff -u <v0.28.0 template> <this PR's head tools/check_publication_gate.py>` — it contains all three hunks (`@@ -885`, the appended canaries, `@@ -2123`) plus the literal.

**Pin that locks an upstream constant (Opus seat MINOR)**: the four-layer depth-boundary pin (`shipped absolute-personal-path string-escape depth boundary (four layers, documented miss)`, L1276–1286) asserts `check_denylist == 0`, which pins the template's fixed-point round count at exactly 3 (mutation `range(4)` turns it RED on purpose). If a future handbook template raises the round count, this repo goes RED on re-copy — the re-copy lane must update or drop this local pin in the same commit and say so in its PR body.

## Mixed-separator decision (#164 note ①)

`/Users\alice` (raw, or after decoding) matches none of the three shipped rules — pre-existing rule shape, not a decode defect. **Decided: not widened in this lane** (widening is a `.publication-denylist` change owned by a denylist lane, e.g. #168 or a family pass). Recorded as a rule-scoped pin `shipped path rules recorded miss: mixed separator (decided in #164, not widened)` so a future widening trips it and forces the record to be updated.

## Evidence (2026-09-05, worktree `family-os-caty-wt/164`, candidate `9eb1add`)

### ① Verbatim proof against x-collector v0.3.3 → exit 0
```
$ python3 -B _handoffs/handbook-154-review-20260905/verify_verbatim.py tools/check_publication_gate.py
decode block (STRING_ESCAPE..scan_views): VERBATIM (68 lines)
selftest string-escape vectors: VERBATIM (120 lines)
```

### ② `python3 -B tools/check_publication_gate.py --selftest` → exit 0
```
ok: selftest_policy_parsers
ok: selftest_shipped_denylist
ok: selftest_scanners
ok: selftest_registry_checks
ok: selftest_end_to_end
PASS (publication gate selftest; assertions: 203)
```
Base 87fb556: 167 (copy-probe child 165). Step 1: 192 / 190 (template +25). Step 3: 203 / 201 (+11 = number of `_selftest_check(` calls added: 136 → 147). `scan_views("private%2Dmarker")[:2]` unchanged (frozen assertion `string-escape existing view order`).

### `make test` → exit 0
```
OK — every module claim matches the registry.
python3 -B tools/render.py --check
OK — generated content is up to date.
```

### ③ Live gate as CI runs it → exit 0, 0 → 0
```
$ python3 -B tools/check_publication_gate.py --root . --account-slug shojikumaru --registry registry/modules.json
denylist rules loaded : 11
denylist matches     : 0
OK — publication gate passed with 14 explicit label whitelist entries.
```
(identical to base 87fb556; the run scans the modified script itself = split-literal self-trip proof.)

### ④ Mutation (scratch copy with `.publication-denylist` beside it, so the shipped-denylist selftest runs; unmutated scratch = 203 green)
| mutation | result | first failing assertion |
|---|---|---|
| escape block `for view in tuple(views):` removed | RED | `shipped absolute-personal-path string-escape scan finding` |
| `range(3)` → `range(1)` | RED | `shipped absolute-personal-path nested serialisation PHP json_encode` |
| `range(3)` → `range(2)` | RED | same |
| `range(3)` → `range(4)` | RED | `shipped absolute-personal-path string-escape depth boundary (four layers, documented miss)` |
| escape block removed **and** generic `string-escape …` vectors commented out | RED | a `shipped …` assertion — the shipped canaries are load-bearing on their own |
Worktree file byte-identical to the unmutated scratch afterwards; `find . -name __pycache__` empty.

### Measured pins
- mixed separator `/Users\alice/project`: `absolute-personal-path` / `windows-user-path` / `wsl-drvfs-user-path` `.search` → all `None` (pinned as recorded miss).
- four layers `\\\\u002fUsers\\\\u002falice`: `scan_views` → 4 views, last `\/Users\/alice`; `check_denylist` → 0 (pinned as documented depth boundary).

## Done when (from #164)

- [x] **PASS** — `STRING_ESCAPE` + `decode_string_escapes` + three-round loop adopted verbatim via template v0.28.0 (①); existing view order unchanged (frozen assertion, ②)
- [x] **PASS** — shipped-rule canaries (`/`, `\/`, `\`, nested PHP, `\u002f`, `\\u002f`) + 8-document clean-control block = 0 across the three path rules; fixed-point / three-rounds / depth-boundary pins present (generic in `selftest_scanners`, shipped four-layer pin in `selftest_shipped_denylist`) (②)
- [x] **PASS** — leak literals split; live gate on the modified source 0 (③)
- [x] **PASS** — mutation-verified (④)
- [x] **PASS** — live gate 0 → 0 (③)
- [x] **PASS** — `make test` green (②)
- [ ] **PENDING** — heterogeneous 5-seat release-gate review: verdicts land in the review ledger comment before merge

## 触ったファイル (L0-6)

- `tools/check_publication_gate.py`

`git diff --stat origin/main...9eb1add` = `tools/check_publication_gate.py | 376 +++++-` (1 file) — matches the declared set (WIP comment on #164). Size looks large because the template blob is swapped wholesale (PR #162 precedent).

## 完了記録 (Completion record)

candidate SHA: 9eb1add96cdb19b32bf5a427f8c2417685bd7e50
implementer: step 1 alpha (Claude Fable 5.1, claude-code session a4e62ff4 — mechanical re-copy + patch re-apply); step 3 Codex gpt-5.6-sol (`codex exec --profile sol -s workspace-write`, sitter-run log `sitter-run-20260905T095316Z-51699.log`)
reviewer: 5-seat release-gate panel per `loom-seats --size M --risk release-gate --absent kimi-k3 --absent gemini-3.8-flash` → opus-5 / glm-5.3 / grok-4.6 / muse-spark-1.3 / codex-sol (verdicts in the review ledger comment)
identity check: 別モデル (writer codex-sol; opus-5 / glm-5.3 / grok-4.6 / muse-spark-1.3 are different models and lineages; codex-sol same-family seat authorized for writer codex-sol by review_council 2026-08-12 — correlated-seats record in the ledger comment)
CI: pending at PR open — updated in the review ledger comment before merge
release: v0.18.1 (shipped behaviour change — the CI publication gate now catches string-escaped personal paths; patch bump because it is a verbatim template adoption; T-5 「迷ったら出荷相当」)
previous release: v0.18.0 → https://github.com/caty-ai/family-os/releases/tag/v0.18.0 (Latest, 2026-09-05, fulfilled)

Refs: family-dev-handbook#154 / PR family-dev-handbook#156 / release v0.28.0 · lead lane caty-ai/x-collector#77 / v0.3.3 · #149 · PR #162 (re-copy pattern) · sibling meetmate#199 (v8.14.1) · follow-up #168 (denylist rules; serialized after this lane, same file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
