### PR TITLE
feat(repo-state): refresh the stamp after a release-sync Release via workflow_run (#165)

### DIFF
--- a/.github/workflows/repo-state-caller.yml
+++ b/.github/workflows/repo-state-caller.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_run:
+    workflows: [release-sync]
+    types: [completed]
   pull_request:
 
 permissions:

--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -10,6 +10,9 @@ name: repository state
 #   release:
 #     types: [published]
 #   workflow_dispatch:
+#   workflow_run:
+#     workflows: [release-sync]
+#     types: [completed]
 #   pull_request:
 # permissions:
 #   contents: write
@@ -23,6 +26,7 @@ name: repository state
 #     with:
 #       generator_ref: v0.18.0
 #
+# Releases created by release-sync with `GITHUB_TOKEN` fire no `release` event; `workflow_run` is the platform event that does fire.
 # The `uses:` ref and `generator_ref` must always move together: a v0.11.0
 # workflow with a v0.11.1 generator fails at `git add` on a repository whose
 # agents entry is null.
@@ -41,6 +45,7 @@ jobs:
     if: >-
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       (github.event_name == 'push' &&
        github.actor != 'github-actions[bot]' &&
        github.actor != 'caty-repo-state-bot[bot]' &&
@@ -70,7 +75,7 @@ jobs:
             echo "no complete app credentials; falling back to GITHUB_TOKEN (v0.11.1 behavior)"
           fi
 
-      - name: check out default branch for release or dispatch
+      - name: check out default branch for release, dispatch, or release-sync completion
         if: github.event_name != 'push'
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -10,6 +10,7 @@ name: repository state
 #   release:
 #     types: [published]
 #   workflow_dispatch:
+#   # release-sync creates Releases with GITHUB_TOKEN, which fires no `release` event; workflow_run does.
 #   workflow_run:
 #     workflows: [release-sync]
 #     types: [completed]
@@ -26,7 +27,6 @@ name: repository state
 #     with:
 #       generator_ref: v0.18.0
 #
-# Releases created by release-sync with `GITHUB_TOKEN` fire no `release` event; `workflow_run` is the platform event that does fire.
 # The `uses:` ref and `generator_ref` must always move together: a v0.11.0
 # workflow with a v0.11.1 generator fails at `git add` on a repository whose
 # agents entry is null.

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -83,13 +83,17 @@ not hand reviewers branch-pinned raw URLs and do not use dates as evidence of fr
 ## 4. CI semantics
 
 The reusable workflow has two jobs. `update` runs for default-branch pushes, published
-releases, and manual dispatches. Push events alone are skipped when the actor is
+releases, manual dispatches, and successful completions of the repository's `release-sync`
+workflow (`workflow_run`). `workflow_run` is the event that actually fires after a Release
+created with `GITHUB_TOKEN`; the caller must declare `on: workflow_run: workflows: [release-sync], types: [completed]`,
+and the reusable job ignores runs whose conclusion is not `success`.
+Push events alone are skipped when the actor is
 `github-actions[bot]` or the organization's stamp app, or the head commit message begins
 `chore(repo-state):`. Release and manual events are never skipped. Every `update` run
-(push, release, and manual dispatch) refreshes release metadata by running the generator with a release refresh requested
+(push, release, manual dispatch, and successful workflow_run) refreshes release metadata by running the generator with a release refresh requested
 (`REPO_STATE_REFRESH_RELEASE=1 repo-state-gen.sh --stamp-mode auto`; the `--refresh-release` flag is equivalent), because Releases created with
 `GITHUB_TOKEN` (the family release-sync carrier) do not emit a `release` event.
-Release and manual-dispatch runs still check out the default branch HEAD, not the release
+Release, manual-dispatch, and `workflow_run` runs still check out the default branch HEAD, not the release
 tag. An explicit GitHub 404 maps the
 release fields to `null`; any other refresh failure fails the run without writing a
 partial update.
@@ -97,7 +101,7 @@ partial update.
 Release refresh adds one `gh api repos/{repo}/releases/latest` call per `update` run
 (at most two with the rebase retry), authenticated with `GITHUB_TOKEN`. A non-404 API
 failure now also fails a push stamp run; this is intentionally fail-closed.
-A Release created after the last default-branch push is picked up by the next `update` run; until then the stamp carries the previous Release (tracked in [#165](https://github.com/caty-ai/family-os/issues/165)).
+A caller that declares the `workflow_run` trigger receives the refresh within one run of the Release; a caller without it keeps the previous Release until its next `update` run.
 
 An update regenerates deterministic output and exits without a commit when the managed
 files have no diff. Otherwise it commits as `github-actions[bot]` with message

--- a/docs/repo-state/spec.md
+++ b/docs/repo-state/spec.md
@@ -84,8 +84,7 @@ not hand reviewers branch-pinned raw URLs and do not use dates as evidence of fr
 
 The reusable workflow has two jobs. `update` runs for default-branch pushes, published
 releases, manual dispatches, and successful completions of the repository's `release-sync`
-workflow (`workflow_run`). `workflow_run` is the event that actually fires after a Release
-created with `GITHUB_TOKEN`; the caller must declare `on: workflow_run: workflows: [release-sync], types: [completed]`,
+workflow (`workflow_run`). `workflow_run` fires on `release-sync` completion regardless of which token created the Release, which is why it closes the gap left by the silent `release` event; the caller must declare `on: workflow_run: workflows: [release-sync], types: [completed]`,
 and the reusable job ignores runs whose conclusion is not `success`.
 Push events alone are skipped when the actor is
 `github-actions[bot]` or the organization's stamp app, or the head commit message begins
@@ -101,7 +100,7 @@ partial update.
 Release refresh adds one `gh api repos/{repo}/releases/latest` call per `update` run
 (at most two with the rebase retry), authenticated with `GITHUB_TOKEN`. A non-404 API
 failure now also fails a push stamp run; this is intentionally fail-closed.
-A caller that declares the `workflow_run` trigger receives the refresh within one run of the Release; a caller without it keeps the previous Release until its next `update` run.
+A caller that declares the `workflow_run` trigger **and pins a reusable workflow that carries this gate (v0.19.0 or later)** receives the refresh within one run of the Release; a caller without either keeps the previous Release until its next `update` run.
 
 An update regenerates deterministic output and exits without a commit when the managed
 files have no diff. Otherwise it commits as `github-actions[bot]` with message

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -534,6 +534,57 @@ test_workflow_refreshes_release_on_every_update_run() {
     printf '%s\n' 'workflow refresh contract: every update run refreshes releases'
 }
 
+test_workflow_run_trigger_contract() {
+    local workflow="$ROOT_DIR/.github/workflows/repo-state.yml"
+    local caller="$ROOT_DIR/.github/workflows/repo-state-caller.yml"
+    local gate
+    gate=$(mktemp "$TEST_TMP/update-gate.XXXXXX")
+    awk '
+        /^  update:/ { update = 1; next }
+        update && /^    if: >-/ { found = 1; next }
+        found && !/^      / { closed = 1; exit }
+        found { print }
+        END { if (!found || !closed) exit 1 }
+    ' "$workflow" > "$gate" || fail 'workflow update if block not found or unclosed'
+
+    grep -Fq "github.event_name == 'workflow_run'" "$gate" \
+        || fail 'workflow update gate does not accept workflow_run'
+    grep -Fq "github.event.workflow_run.conclusion == 'success'" "$gate" \
+        || fail 'workflow update gate does not require successful completion'
+    grep -Fq "github.event_name == 'release'" "$gate" \
+        || fail 'workflow update gate does not accept release'
+    grep -Fq "github.event_name == 'workflow_dispatch'" "$gate" \
+        || fail 'workflow update gate does not accept workflow_dispatch'
+    grep -Fq 'chore(repo-state):' "$gate" \
+        || fail 'workflow update gate lost the push loop guard'
+
+    awk '
+        /- name: check out default branch/ { found = 1; next }
+        found { print; exit }
+    ' "$workflow" | grep -Fq "if: github.event_name != 'push'" \
+        || fail 'default-branch checkout is not gated on non-push events'
+
+    grep -Fxq '#   workflow_run:' "$workflow" \
+        || fail 'caller example does not declare workflow_run'
+    grep -Fxq '#     workflows: [release-sync]' "$workflow" \
+        || fail 'caller example does not listen to release-sync'
+    grep -Fxq '#     types: [completed]' "$workflow" \
+        || fail 'caller example does not listen to completed runs'
+    grep -Fxq '  workflow_run:' "$caller" \
+        || fail 'caller does not declare workflow_run'
+    grep -Fxq '    workflows: [release-sync]' "$caller" \
+        || fail 'caller does not listen to release-sync'
+    grep -Fxq '    types: [completed]' "$caller" \
+        || fail 'caller does not listen to completed runs'
+
+    awk '
+        /^  check:/ { check = 1; next }
+        check && /^    if:/ { print; exit }
+    ' "$workflow" | grep -Fxq "    if: github.event_name == 'pull_request'" \
+        || fail 'workflow check job is not gated on pull_request'
+    printf '%s\n' 'workflow_run trigger contract: release-sync completion refreshes the stamp'
+}
+
 test_refresh_release_404_maps_null() {
     local repo mock_dir git_marker
     repo=$(new_repo FOR-AGENTS.md)
@@ -650,6 +701,7 @@ test_refresh_release_flag_queries_gh
 test_refresh_release_env_queries_gh
 test_refresh_release_replaces_stale_existing_tag
 test_workflow_refreshes_release_on_every_update_run
+test_workflow_run_trigger_contract
 test_refresh_release_404_maps_null
 test_refresh_release_transport_error_is_fatal
 test_refresh_release_http_error_is_fatal

--- a/tools/selftest_repo_state_gen.sh
+++ b/tools/selftest_repo_state_gen.sh
@@ -551,6 +551,13 @@ test_workflow_run_trigger_contract() {
         || fail 'workflow update gate does not accept workflow_run'
     grep -Fq "github.event.workflow_run.conclusion == 'success'" "$gate" \
         || fail 'workflow update gate does not require successful completion'
+    sed 's/^[[:space:]]*//' "$gate" | grep -Fxq "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||" \
+        || fail 'workflow update gate does not join successful workflow_run as an alternative'
+    if sed 's/[[:space:]]*$//' "$gate" | sed '$d' | grep -vE '(\|\||&&)$'; then
+        fail 'workflow update gate has a line without an operator join'
+    fi
+    sed 's/[[:space:]]*$//' "$gate" | tail -n 1 | grep -Eq '\)$' \
+        || fail 'workflow update gate final line does not close the expression'
     grep -Fq "github.event_name == 'release'" "$gate" \
         || fail 'workflow update gate does not accept release'
     grep -Fq "github.event_name == 'workflow_dispatch'" "$gate" \


### PR DESCRIPTION
## Why

After v0.18.0 (#163) the stamp refreshes on every `update` run, but a Release created by the release-sync carrier with `GITHUB_TOKEN` fires no `release` event, so a repo that releases and then goes quiet keeps the previous `latest_tag` until the next unrelated push to main (live instance: x-collector `v0.4.0`, recorded on #165). Owner picked option (a).

## What changed

- `.github/workflows/repo-state.yml` — the `update` job also runs on `workflow_run` when `github.event.workflow_run.conclusion == 'success'`; it takes the existing non-push path (default-branch checkout, `REPO_STATE_REFRESH_RELEASE=1`, bot stamp commit, one-rebase retry). Failed/cancelled release-sync runs do not trigger it. Header caller example gains the trigger and a one-line reason.
- `.github/workflows/repo-state-caller.yml` — family-os's own caller declares `on: workflow_run: workflows: [release-sync], types: [completed]`. Pins stay at `v0.18.0` until the release (the v0.18.0 gate simply ignores `workflow_run` until then).
- `docs/repo-state/spec.md` §4 — the new trigger, the `success` gate, default-branch checkout for `workflow_run`, and the residual behaviour for callers without the trigger (replaces the #165 window sentence).
- `tools/selftest_repo_state_gen.sh` — `test_workflow_run_trigger_contract`: reusable `update` gate contains the `workflow_run` + `success` branch and keeps release / dispatch / push loop guard; non-push checkout still gated `!= 'push'`; header example and the real caller declare the trigger; `check` job still `pull_request`-only.
- `tools/repo-state-gen.sh` — unchanged.

Every family carrier is named `release-sync` (verified on all 13 callers on 2026-09-05), so one workflow name suffices.

## Named risk (shown to every seat)

`workflow_run` semantics (default-branch file, default-branch `GITHUB_SHA`/`ref`, concurrency with push runs), loop/storm analysis (re-run of release-sync also emits `completed`; regeneration is idempotent), race with release-sync fulfilment, token behaviour, double stamp commits vs the audit identity invariant, and whether the contract test fails on a gate that "looks right but never fires".

## Files touched (L0-6)

Declared in the WIP comment on #165: `.github/workflows/repo-state.yml`, `.github/workflows/repo-state-caller.yml`, `docs/repo-state/spec.md`, `tools/selftest_repo_state_gen.sh`. `git diff --stat origin/main...7e97325` lists exactly those four.

## Review

Round 1 on `4670081` (blind, same brief, read-only; requested = actual model):

| seat | effort | verdict | findings |
|---|---|---|---|
| GLM 5.3 (`glm` CLI) | high, mutation script + suite executed | GO | MINOR: spec sentence version-unqualified (caller must also pin a reusable with this gate). MINOR: contract test survives a deleted `\|\|` (M7). NIT: "actually fires after a GITHUB_TOKEN Release" wording. NIT: verify Done-when with a stable tag (prerelease is invisible to `releases/latest`). |
| Opus 5 (code-reviewer subagent) | high, 8 mutants | GO-with-fixes | MINOR: same spec sentence. MINOR: same grep-only gap (M7). NIT: DESIGN.md (frozen) drift since #163. NIT: rationale comment placement. Notes the change avoids the `workflow_run` privilege-escalation shape (checks out the default branch, never `workflow_run.head_sha`). |
| Grok 4.6 (`grok` CLI, substitute for Kimi K3) | high, actionlint + mutation | GO | MINOR: contract test passes on missing `\|\|` and on `&&`->`\|\|` (extra-fire shapes; never-fire typos are caught). NIT: same spec sentence. NIT: §4 stamp-count sentence omits the stacked stamp. |

Arbitration (evidence, not seat count): all three seats converged on the same two items -> fixed in delta `7e97325` (contract test asserts the exact one-line arm with its trailing `\|\|` and that every non-final gate line ends with an operator; §4 sentence now requires a reusable >= v0.19.0; rationale comment moved next to the `workflow_run` example). Codex's mutation check on a scratch copy: trailing-`\|\|` deletion and `&&`->`\|\|` both fail with `workflow update gate does not join successful workflow_run as an alternative`. DESIGN.md stays frozen (Opus NIT). Verified with no finding by all seats: no loop path, concurrency shared with push runs, default-branch checkout, token parity with dispatch, stacked stamps satisfy the audit invariant, release-sync success-without-Release paths degrade to "already current; no commit".

Delta r1 verification by Opus 5 (raised both MINORs), on `7e97325`: **cumulative GO**. Fresh scratch copy: baseline green; M7 (trailing `||` deleted) RED; M9 (`&&`->`||` inside the arm) RED, both on the exact-arm assertion. MINOR-1 / MINOR-2 / NIT resolved. Residual, out of scope and pre-existing: the shape check does not pin which operator joins the push-actor guard lines (a follow-up assertion would give symmetry).

Alpha (Claude Fable 5.1) wrote the brief, delegated the diff and the delta to Codex, and arbitrates; Alpha is not counted as a seat. Seat composition from `loom-seats --size M --absent kimi-k3`.

## 完了記録 (Completion record)

candidate SHA: 7e97325765ec3d1d14551f2ff1931ebe0b4397ae (round-1 head 4670081 + review delta)
implementer: Codex (gpt-6-astra, medium) via `codex exec`, brief by Alpha
reviewer: GLM 5.3 / Opus 5 (code-reviewer subagent) / Grok 4.6 — independent read-only seats, same blind brief (Kimi K3 absent: weekly quota)
identity check: 別モデル (writer Codex ≠ every seat; orchestrator Alpha not a seat)
CI: green on 4670081 and re-run on 7e97325 (2026-09-05) — all required checks pass (test-lint test/lint/test-macos, repo-state check, gitleaks, history-check, risk-review-gate, registry, family footer, publication gate, evidence freshness, links); runs https://github.com/caty-ai/family-os/actions/runs/33962652852 (test-lint) and https://github.com/caty-ai/family-os/actions/runs/33962652682 (repo-state check).
release: v0.19.0 (minor — the reusable workflow gains a trigger path every caller will adopt; annotated tag on the squash-merge commit + Release via release-sync; then caller rollout: trigger + pin bump in a separate batch)
previous release: v0.18.1 → https://github.com/caty-ai/family-os/releases/tag/v0.18.1 (2026-09-05 10:45Z, #169 `769c33d`, fulfilled, published not draft; tag is an ancestor of this PR head). Merges since v0.18.0: #167 (`6bbb012`, `release: N/A ③`) and #169 (v0.18.1). Pre-merge re-check on 2026-09-05: origin/main `f6e9852` unchanged since the PR base, branch is on top of it (no conflict possible), `make test` green at 7e97325.

correlated-seats record (L1-10): scope = this PR only / pair = Opus 5 ↔ Alpha (Fable 5.1, orchestrator, not a seat) / reason = roster panel for size M; writer is Codex / approved_by = Sho (review_council 2026-08-21) / date = 2026-09-05 / writer condition = writer must be Codex (holds).

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| After a release-sync Release with no further push, the caller's `latest_tag` equals the new Release within one run (verified on one caller with run URLs) | PENDING — needs a real family release after the caller rollout | By construction (gate + caller trigger) and contract test now; live verification at the next family release on a bumped caller, recorded on #165 (LC-1). |
| spec §4 describes the trigger that fires after a release-sync Release | PASS | spec §4 diff in this PR, 2026-09-05 |
| selftest covers the new trigger path | PASS | `bash tools/selftest_repo_state_gen.sh` → `workflow_run trigger contract: release-sync completion refreshes the stamp` … `selftest_repo_state_gen: ok`; `make test` green (2026-09-05, worktree at 7e97325) |

Tracked in #165 — stays open until the live verification on a caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
