### PR TITLE
gate: adopt wsl-unc-linux-home / host-mount-user-path verbatim from x-collector v0.3.4 + canaries + recorded won't-fix (#168)

### DIFF
--- a/.publication-denylist
+++ b/.publication-denylist
@@ -17,6 +17,17 @@ windows-user-path	\b[A-Za-z]:[\\/]+Users[\\/]+(?![<{])[\w.-]+
 # 先頭セパレータが単数 `[\\/]` なのも意図的（`+` は長いセパレータ連続で二次バックトラッキングを起こす）。
 # 代償は URL パス形の過検出だが fail-closed 側であり、3リポ537ファイルの実測で誤検出ゼロ。
 wsl-drvfs-user-path	[\\/]mnt[\\/]+[A-Za-z][\\/]+users[\\/]+(?![<{])[\w.-]+
+# `wsl-unc-linux-home` / `host-mount-user-path` = caty-ai/x-collector#78 (PR#101 / v0.3.4) で凍結した family 形をそのまま採用。
+# `wsl-unc-linux-home` は Windows 側に現れる `absolute-personal-path` の鏡像として、`\\wsl$` と
+# `\\wsl.localhost` の `<distro>\\home\\<name>` を対象にする。
+# `host-mount-user-path` は `/cygdrive/`、`/host_mnt/`、および Docker Desktop の
+# `/run/desktop/mnt/host/` を含む `/mnt/<root>/<drive>/users/` を対象にする。
+# bare `[\\/][A-Za-z][\\/]+users` は 3 family gate script 自身の selftest canary に 390 件 self-hit して全 family gate を赤にし、先行 lookbehind（例: `(?<![\w\\])[\\/][A-Za-z][\\/]+users`）は corpus 0 件だが `vscode-remote://wsl+<distro>/c/users/<name>`、`sftp://<host>/c/users/<name>`、`https://<host>/c/users/<name>`、`file://localhost/c/users/<name>` で fail-open（caty-ai/x-collector#76）する。
+# family shape は先行 anchor を持たないためいずれも採用せず、将来 lookbehind anchor を許す family decision があれば再評価する；`/c/users/`（Git-Bash MSYS を含む）と `/mnt` 外は対象外、tool 出力の `/c/Users/<name>` は `absolute-personal-path` が捕捉する。
+# `/mnt/cdrive/users/` は #76 の trade を変更せず対象外とする。
+# `absolute-personal-path` を case-insensitive 化して代用してはならない。
+wsl-unc-linux-home	wsl(?:\$|\.localhost)[\\/]+[^\\/\s]+[\\/]+home[\\/]+(?![<{])[\w.-]+
+host-mount-user-path	[\\/](?:cygdrive|host_mnt|mnt[\\/]+[\w.-]+)[\\/]+[A-Za-z][\\/]+users[\\/]+(?![<{])[\w.-]+
 private-network-address	\b100\.(?:6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.\d+\.\d+\b
 local-service-host-port	localhost:\d+
 local-service-loopback	\b(?:127\.0\.0\.1|0\.0\.0\.0)\b

--- a/tools/check_publication_gate.py
+++ b/tools/check_publication_gate.py
@@ -828,6 +828,10 @@ def _selftest_check(condition, message):
         raise RuntimeError("selftest failed: %s" % message)
 
 
+def _selftest_rules_without(rules, name):
+    return tuple(rule for rule in rules if rule[0] != name)
+
+
 def _fixture_registry(account_slug="neutral-owner"):
     return {
         "languages": ["en", "ja"],
@@ -1283,6 +1287,285 @@ def selftest_shipped_denylist():
         == 0
         and depth_boundary_failures == [],
         "shipped absolute-personal-path string-escape depth boundary (four layers, documented miss)",
+    )
+    shipped_rules = tuple(load_denylist(root))
+    wsl_unc_patterns = [
+        pattern for name, pattern in shipped_rules if name == "wsl-unc-linux-home"
+    ]
+    _selftest_check(len(wsl_unc_patterns) == 1, "shipped wsl-unc-linux-home rule")
+    wsl_unc_linux_home = wsl_unc_patterns[0]
+    wsl_unc_leak = "\\\\wsl$\\Ubuntu\\ho" + "me\\alice\\family-os\\.env"
+    wsl_localhost_leak = "\\\\wsl.localhost\\Ubuntu\\ho" + "me\\alice\\.ssh"
+    wsl_unc_case_leak = "\\\\WSL$\\UBUNTU\\HO" + "ME\\BOB"
+    wsl_unc_cjk_leak = "\\\\wsl$\\Ubuntu-22.04\\ho" + "me\\翔太郎"
+    wsl_unc_placeholder_distro_leak = "\\\\wsl$\\<distro>\\ho" + "me\\alice"
+    wsl_unc_file_url_leak = "file://wsl$/Ubuntu/ho" + "me/alice"
+    wsl_unc_extended_leak = "\\\\?\\UNC\\wsl.localhost\\Debian\\ho" + "me\\carol"
+    wsl_unc_json_backslash_leak = r"\\\\wsl$\\Ubuntu\\ho" + r"me\\alice"
+    wsl_unc_json_solidus_leak = "\\/\\/wsl.localhost\\/Ubuntu\\/ho" + "me\\/alice"
+    _selftest_check(
+        all(
+            wsl_unc_linux_home.search(sample) is not None
+            for sample in (
+                wsl_unc_leak,
+                wsl_localhost_leak,
+                wsl_unc_case_leak,
+                wsl_unc_cjk_leak,
+                wsl_unc_placeholder_distro_leak,
+                wsl_unc_file_url_leak,
+                wsl_unc_extended_leak,
+                wsl_unc_json_backslash_leak,
+                wsl_unc_json_solidus_leak,
+            )
+        ),
+        "shipped wsl-unc-linux-home leaks",
+    )
+    wsl_unc_match = wsl_unc_linux_home.search(wsl_unc_leak)
+    _selftest_check(
+        wsl_unc_match is not None
+        and wsl_unc_match.group(0) == "wsl$\\Ubuntu\\ho" + "me\\alice",
+        "shipped wsl-unc-linux-home span pin",
+    )
+    wsl_unc_dotted_leak = "\\\\wsl$\\Ubuntu\\ho" + "me\\j" ".doe"
+    wsl_unc_dotted_match = wsl_unc_linux_home.search(wsl_unc_dotted_leak)
+    _selftest_check(
+        wsl_unc_dotted_match is not None
+        and wsl_unc_dotted_match.group(0) == "wsl$\\Ubuntu\\ho" + "me\\j" ".doe",
+        "shipped wsl-unc-linux-home dotted leak",
+    )
+    wsl_unc_hyphenated_leak = "\\\\wsl$\\Ubuntu\\ho" + "me\\anne" "-marie"
+    wsl_unc_hyphenated_match = wsl_unc_linux_home.search(wsl_unc_hyphenated_leak)
+    _selftest_check(
+        wsl_unc_hyphenated_match is not None
+        and wsl_unc_hyphenated_match.group(0)
+        == "wsl$\\Ubuntu\\ho" + "me\\anne" "-marie",
+        "shipped wsl-unc-linux-home hyphenated leak",
+    )
+    _selftest_check(
+        all(
+            wsl_unc_linux_home.search(sample) is None
+            for sample in (
+                "\\\\wsl$\\Ubuntu\\ho" + "me\\<name>",
+                "\\\\wsl$\\Ubuntu\\ho" + "me\\{name}",
+                "\\\\wsl$\\Ubuntu\\etc\\passwd",
+                "\\\\wsl$\\Ubuntu\\mn" + "t\\c\\users\\alice",
+                "\\\\server\\share\\home\\alice",
+                "wsl.localhost is the new hostname; see /home/ for details",
+                "https://docs.example.com/wsl/homework/alice",
+                "/mn" + "t/backup/users/shared",
+                "https://api.github.com/users/alice",
+                "mailto:Users/alice",
+            )
+        ),
+        "shipped wsl-unc-linux-home clean controls",
+    )
+    wsl_unc_failures = []
+    _selftest_check(
+        check_denylist({"unc.txt": wsl_unc_leak}, shipped_rules, wsl_unc_failures) == 1
+        and wsl_unc_failures == ["denylist: unc.txt:1 contains wsl-unc-linux-home"],
+        "shipped wsl-unc-linux-home scan finding",
+    )
+    wsl_unc_mutation_failures = []
+    _selftest_check(
+        check_denylist(
+            {"unc.txt": wsl_unc_leak},
+            _selftest_rules_without(shipped_rules, "wsl-unc-linux-home"),
+            wsl_unc_mutation_failures,
+        )
+        == 0
+        and wsl_unc_mutation_failures == [],
+        "shipped wsl-unc-linux-home mutation",
+    )
+    wsl_unc_decoded_failures = []
+    _selftest_check(
+        check_denylist(
+            {"enc.txt": "%5C%5Cwsl%24%5CUbuntu%5Cho" + "me%5Calice"},
+            shipped_rules,
+            wsl_unc_decoded_failures,
+        )
+        == 1
+        and wsl_unc_decoded_failures
+        == ["denylist: enc.txt:1 contains wsl-unc-linux-home (decoded view)"],
+        "shipped wsl-unc-linux-home decoded scan finding",
+    )
+    wsl_unc_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {
+                "esc.txt": "\\u005c\\u005cwsl$\\u005cUbuntu\\u005cho"
+                + "me\\u005calice"
+            },
+            shipped_rules,
+            wsl_unc_string_escape_failures,
+        )
+        == 1
+        and wsl_unc_string_escape_failures
+        == ["denylist: esc.txt:1 contains wsl-unc-linux-home (decoded view)"],
+        "shipped wsl-unc-linux-home string-escape scan finding",
+    )
+    host_mount_patterns = [
+        pattern for name, pattern in shipped_rules if name == "host-mount-user-path"
+    ]
+    _selftest_check(len(host_mount_patterns) == 1, "shipped host-mount-user-path rule")
+    host_mount_user_path = host_mount_patterns[0]
+    cygdrive_leak = "/cygdri" + "ve/c/users/alice/.ssh/id_rsa"
+    host_mnt_leak = "/host_m" + "nt/c/users/alice"
+    docker_desktop_leak = "/run/desktop/mn" + "t/host/c/users/alice"
+    custom_mnt_leak = "/mn" + "t/win/c/users/alice/family-os/.env"
+    custom_mnt_cjk_leak = "/mn" + "t/host/d/users/翔太郎"
+    cygdrive_case_leak = "/CYGDRI" + "VE/C/USERS/BOB"
+    cygdrive_backslash_leak = "\\cygdri" + "ve\\c\\users\\alice"
+    cygdrive_env_leak = "export HOME=/cygdri" + "ve/c/users/alice"
+    host_mnt_file_url_leak = "file:///host_m" + "nt/c/users/carol/.env"
+    custom_mnt_abbreviated_leak = ".../mn" + "t/win/c/users/alice/x.ts"
+    cygdrive_solidus_leak = "\\/cygdri" + "ve\\/c\\/users\\/alice"
+    custom_mnt_vscode_leak = (
+        "vscode-remote://wsl+Ubuntu/mn" + "t/win/c/users/alice"
+    )
+    _selftest_check(
+        all(
+            host_mount_user_path.search(sample) is not None
+            for sample in (
+                cygdrive_leak,
+                host_mnt_leak,
+                docker_desktop_leak,
+                custom_mnt_leak,
+                custom_mnt_cjk_leak,
+                cygdrive_case_leak,
+                cygdrive_backslash_leak,
+                cygdrive_env_leak,
+                host_mnt_file_url_leak,
+                custom_mnt_abbreviated_leak,
+                cygdrive_solidus_leak,
+                custom_mnt_vscode_leak,
+            )
+        ),
+        "shipped host-mount-user-path leaks",
+    )
+    cygdrive_match = host_mount_user_path.search(cygdrive_leak)
+    docker_desktop_match = host_mount_user_path.search(docker_desktop_leak)
+    _selftest_check(
+        cygdrive_match is not None
+        and cygdrive_match.group(0) == "/cygdri" + "ve/c/users/alice"
+        and docker_desktop_match is not None
+        and docker_desktop_match.group(0) == "/mn" + "t/host/c/users/alice",
+        "shipped host-mount-user-path span pin",
+    )
+    host_mount_dotted_leak = "/cygdri" + "ve/c/users/j" ".doe"
+    host_mount_dotted_match = host_mount_user_path.search(host_mount_dotted_leak)
+    _selftest_check(
+        host_mount_dotted_match is not None
+        and host_mount_dotted_match.group(0) == "/cygdri" + "ve/c/users/j" ".doe",
+        "shipped host-mount-user-path dotted leak",
+    )
+    host_mount_hyphenated_leak = "/host_m" + "nt/c/users/anne" "-marie"
+    host_mount_hyphenated_match = host_mount_user_path.search(host_mount_hyphenated_leak)
+    _selftest_check(
+        host_mount_hyphenated_match is not None
+        and host_mount_hyphenated_match.group(0)
+        == "/host_m" + "nt/c/users/anne" "-marie",
+        "shipped host-mount-user-path hyphenated leak",
+    )
+    _selftest_check(
+        all(
+            host_mount_user_path.search(sample) is None
+            for sample in (
+                "/cygdri" + "ve/c/users/<user>",
+                "/cygdri" + "ve/c/users/{user}",
+                "/cygdri" + "ve/c/Windows/System32",
+                "/cygdri" + "ve/cc/users/alice",
+                "/host_m" + "nt/users/alice",
+                "/mn" + "t/backup/users/shared",
+                "/mn" + "t/c/users/alice",
+                "/mn" + "t/1/users/foo",
+                "/opt/c/users/alice",
+                "https://api.github.com/users/alice",
+                "mailto:Users/alice",
+            )
+        ),
+        "shipped host-mount-user-path clean controls",
+    )
+    _selftest_check(
+        all(
+            host_mount_user_path.search(sample) is None
+            for sample in (
+                "/c/us" + "ers/alice",
+                "/mn" + "t/cdrive/users/alice",
+                "/win/c/us" + "ers/alice",
+            )
+        ),
+        "shipped host-mount-user-path recorded won't-fix misses",
+    )
+    host_mount_non_overlap_failures = []
+    _selftest_check(
+        check_denylist(
+            {"drvfs.txt": "/mn" + "t/c/users/alice"},
+            shipped_rules,
+            host_mount_non_overlap_failures,
+        )
+        == 1
+        and host_mount_non_overlap_failures
+        == ["denylist: drvfs.txt:1 contains wsl-drvfs-user-path"],
+        "shipped host-mount-user-path non-overlap pin",
+    )
+    host_mount_scan_cases = (
+        ("cygdrive.txt", cygdrive_leak),
+        ("host-mnt.txt", host_mnt_leak),
+        ("custom-mnt.txt", custom_mnt_leak),
+    )
+    host_mount_scan_results = []
+    for path, sample in host_mount_scan_cases:
+        scan_failures = []
+        count = check_denylist({path: sample}, shipped_rules, scan_failures)
+        host_mount_scan_results.append((count, scan_failures))
+    _selftest_check(
+        host_mount_scan_results
+        == [
+            (1, ["denylist: cygdrive.txt:1 contains host-mount-user-path"]),
+            (1, ["denylist: host-mnt.txt:1 contains host-mount-user-path"]),
+            (1, ["denylist: custom-mnt.txt:1 contains host-mount-user-path"]),
+        ],
+        "shipped host-mount-user-path scan finding",
+    )
+    host_mount_mutation_results = []
+    for path, sample in host_mount_scan_cases:
+        mutation_failures = []
+        count = check_denylist(
+            {path: sample},
+            _selftest_rules_without(shipped_rules, "host-mount-user-path"),
+            mutation_failures,
+        )
+        host_mount_mutation_results.append((count, mutation_failures))
+    _selftest_check(
+        host_mount_mutation_results == [(0, []), (0, []), (0, [])],
+        "shipped host-mount-user-path mutation",
+    )
+    host_mount_decoded_failures = []
+    _selftest_check(
+        check_denylist(
+            {"enc.txt": "%2Fcygdri" + "ve%2Fc%2Fusers%2Falice"},
+            shipped_rules,
+            host_mount_decoded_failures,
+        )
+        == 1
+        and host_mount_decoded_failures
+        == ["denylist: enc.txt:1 contains host-mount-user-path (decoded view)"],
+        "shipped host-mount-user-path decoded scan finding",
+    )
+    host_mount_string_escape_failures = []
+    _selftest_check(
+        check_denylist(
+            {
+                "esc.txt": "\\u002fhost_m"
+                + "nt\\u002fc\\u002fusers\\u002falice"
+            },
+            shipped_rules,
+            host_mount_string_escape_failures,
+        )
+        == 1
+        and host_mount_string_escape_failures
+        == ["denylist: esc.txt:1 contains host-mount-user-path (decoded view)"],
+        "shipped host-mount-user-path string-escape scan finding",
     )
 
 
@@ -2718,7 +3001,7 @@ def selftest_end_to_end():
         )
         _selftest_check(
             result.returncode == 0
-            and "PASS (publication gate selftest; assertions: 201)" in result.stdout
+            and "PASS (publication gate selftest; assertions: 223)" in result.stdout
             and "skip: selftest_shipped_denylist" not in result.stdout,
             "real-root copy-probe runs shipped-denylist selftest: %r" % result.stdout,
         )


### PR DESCRIPTION
Tracked in #168 (leaves #168 open until the MERGED comment with the tag URL lands)

## What

Adopt the two frozen family denylist rules from caty-ai/x-collector#78 (PR x-collector#101, Release v0.3.4) **verbatim**, directly after `wsl-drvfs-user-path`, and record the won't-fix for bare `/c/users/<name>` with the rule so it is not rediscovered as a bug. Same adoption shape as #149 (x-collector#75) and #164 (x-collector#77).

| rule | catches (previously MISS on every shipped rule and every decode view) |
|---|---|
| `wsl-unc-linux-home` | `\\wsl$\<distro>\home\<name>`, `\\wsl.localhost\<distro>\home\<name>` (Windows-side mirror of `/home/<name>`) |
| `host-mount-user-path` | `/cygdrive/c/users/<name>`, `/host_mnt/c/users/<name>`, `/mnt/<root>/c/users/<name>` incl. Docker Desktop `/run/desktop/mnt/host/c/users/<name>` |

Recorded won't-fix (comment block in `.publication-denylist`): bare `[\\/][A-Za-z][\\/]+users` self-hits the three family gate scripts' own selftest canaries (390 hits, every family gate red on itself); a leading lookbehind has 0 corpus hits but fails open on `vscode-remote://wsl+…`, `sftp://`, `https://`, `file://localhost/` (the #76 class the family shape exists to avoid). `/c/users/` (incl. Git-Bash MSYS) and roots outside `/mnt` stay out of scope; tool-printed `/c/Users/<name>` is caught by `absolute-personal-path`; `/mnt/cdrive/users/` keeps the #76 trade.

`tools/check_publication_gate.py` — selftest only, no scanning-logic change: helper `_selftest_rules_without` (verbatim from x-collector v0.3.4) and the 22 lead-lane canaries mirrored into `selftest_shipped_denylist` after the #164 block. Renames vs the lead lane: `rules`→`shipped_rules` (bound as `tuple(load_denylist(root))` so the earlier 1-tuple `rules` is not rebound), `wsl_user_path`→`wsl_drvfs_user_path`, `local_user_path`→`absolute_personal_path`, message prefix `repository`→`shipped`, `x-collector`→`family-os` in two leak literals. Otherwise byte-identical to x-collector v0.3.4 `selftest_repository_policy` L1052–1330 (mechanical diff after the five renames: 0 lines).

**Fourth local hunk to repeat on the next template re-copy** (PR #169 lists the first three): `_selftest_rules_without` after `_selftest_check` + the 22 canaries at the end of `selftest_shipped_denylist` (messages `shipped wsl-unc-linux-home rule` … `shipped host-mount-user-path string-escape scan finding`), copy-probe literal 201 → **223**.

## Evidence (2026-09-05, worktree `family-os-caty-wt/168`, candidate `7b8abc9`)

### ① Rule lines verbatim → `cmp` silent, exit 0
```
$ sed -n '28,29p' <x-collector v0.3.4 .publication-denylist> > xc-rules
$ grep '^wsl-unc-linux-home\|^host-mount-user-path' .publication-denylist > fos-rules
$ cmp xc-rules fos-rules && echo RULES-VERBATIM
RULES-VERBATIM
```
`git diff 7148a4f 7b8abc9 -- .publication-denylist` = additions only (9 comment lines + 2 rule lines between old L19/L20); 11 → 13 rules.

### ② Frozen template blocks untouched → exit 0
```
$ python3 -B verify_verbatim.py tools/check_publication_gate.py
decode block (STRING_ESCAPE..scan_views): VERBATIM (68 lines)
selftest string-escape vectors: VERBATIM (120 lines)
```

### ③ `python3 -B tools/check_publication_gate.py --selftest` → exit 0
```
ok: selftest_shipped_denylist
…
PASS (publication gate selftest; assertions: 225)
```
Base 7148a4f: 203 (copy-probe child 201). Candidate: 225 / 223 (+22 = number of `_selftest_check(` calls added; the only removed line in the script diff is the old `201` literal).

### `make test` → exit 0
```
OK — every module claim matches the registry.
python3 -B tools/render.py --check
OK — generated content is up to date.
```

### ④ Live gate as CI runs it → exit 0, 0 → 0
```
$ python3 -B tools/check_publication_gate.py --root . --account-slug shojikumaru --registry registry/modules.json
denylist rules loaded : 13
denylist matches     : 0
OK — publication gate passed with 14 explicit label whitelist entries.
```
(the run scans the modified script and the denylist comment block themselves = split-literal / comment self-trip proof.)

### ⑤ Mutation (scratch copy with `.publication-denylist` beside the script; unmutated scratch = 225 green)
| mutation on the scratch denylist | result | first failing assertion |
|---|---|---|
| delete `wsl-unc-linux-home` line | RED | `shipped wsl-unc-linux-home rule` |
| delete `host-mount-user-path` line | RED | `shipped host-mount-user-path rule` |
| neuter UNC regex `home` → `hxme` | RED | `shipped wsl-unc-linux-home leaks` |
| remove `cygdrive\|` branch | RED | `shipped host-mount-user-path leaks` |
| remove `host_mnt\|` branch | RED | `shipped host-mount-user-path leaks` |
| widen drive `[A-Za-z]` → `[A-Za-z]+` | RED | `shipped host-mount-user-path clean controls` (`/mnt/backup/users/shared`) |
Worktree files untouched afterwards; `find . -name __pycache__` empty; no `.orig` / `.rej`.

### Pins carried from the lead lane
- non-overlap: `/mnt/c/users/<name>` → `wsl-drvfs-user-path` only (count 1, not 2); `/mnt/win/c/users/<name>` → `host-mount-user-path` only.
- recorded won't-fix misses (rule-scoped): `/c/users/<name>`, `/opt/c/users/<name>`, `/mnt/cdrive/users/<name>` match neither new rule; `/c/Us…ers/<name>` matches `absolute-personal-path`.
- mixed-separator pin from #164 unchanged (rule not widened here).

## Done when (from #168)

- [x] **PASS** — both rule lines adopted verbatim after `wsl-drvfs-user-path` (①); comment block records the two adopted classes + both rejected shapes with reasons
- [x] **PASS** — 22 canaries mirroring the lead lane against this repo's rules: raw / JSON `\\\\` / `\/` / `%5C` `%2F` / `\` `/` / string-escape forms, span pins, dotted + hyphenated, clean controls, non-overlap pin, recorded won't-fix misses, mutation checks via `_selftest_rules_without` (③, ⑤)
- [x] **PASS** — leak literals split; live gate on the modified source 0 (④)
- [x] **PASS** — live gate 0 → 0 (④)
- [x] **PASS** — `make test` green (③)
- [ ] **PENDING** — heterogeneous 5-seat release-gate review: verdicts land in the review ledger comment before merge

## 触ったファイル (L0-6)

- `.publication-denylist`
- `tools/check_publication_gate.py` (selftest only)

`git diff --stat 7148a4f...7b8abc9` = `.publication-denylist | 11 ++`, `tools/check_publication_gate.py | 285 +++-` (2 files) — matches the declared set (WIP comment on #168). 296 lines > 250 = `pr-size` needs `size-exempt` (22 canaries mirrored verbatim, same as PR #169).

## 完了記録 (Completion record)

candidate SHA: 7b8abc954a38ff7a1879fb04fd21beea43fafec1
implementer: Codex gpt-5.6-sol (`codex exec --profile sol -s workspace-write`, sitter-run log `sitter-run-20260905T123647Z-28115.log`); brief + commit by alpha (Claude Fable 5.1, claude-code session dd813edb)
reviewer: 5-seat release-gate panel per `loom-seats --size M --risk release-gate --absent kimi-k3 --absent gemini-3.8-flash` → opus-5 / glm-5.3 / grok-4.6 / muse-spark-1.3 / codex-sol (verdicts in the review ledger comment)
identity check: 別モデル (writer codex-sol; opus-5 / glm-5.3 / grok-4.6 / muse-spark-1.3 are different models and lineages; codex-sol same-family seat authorized for writer codex-sol by review_council 2026-08-12 — correlated-seats record in the ledger comment)
CI: pending at PR open — updated in the review ledger comment before merge
release: v0.19.1 (shipped behaviour change — the CI publication gate now catches the four WSL2/Windows spellings; patch bump because it is a verbatim adoption of frozen family rules; T-5 「迷ったら出荷相当」)
previous release: v0.19.0 → https://github.com/caty-ai/family-os/releases/tag/v0.19.0 (Latest, 2026-09-05, tag on main `91704ff`, fulfilled)

Refs: lead lane caty-ai/x-collector#78 / PR x-collector#101 / v0.3.4 · #149 (x-collector#75) · #164 / PR #169 (x-collector#77; previous local hunks) · sibling meetmate#207 · upstream handbook#157 (template does not ship the denylist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
